### PR TITLE
[Feat] Self-hosted runner 기반 Blue-Green 무중단 배포

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -6,6 +6,9 @@ on:
       - develop
   pull_request:
 
+env:
+  APP_NAME: allreva-springboot
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -29,11 +32,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Create firebase-service-account.json
-        run: |
-          mkdir -p src/main/resources/firebase
-          echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}" | base64 --decode > src/main/resources/firebase/firebase-service-account.json
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -50,11 +48,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Create firebase-service-account.json
-        run: |
-          mkdir -p src/main/resources/firebase
-          echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}" | base64 --decode > src/main/resources/firebase/firebase-service-account.json
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -77,14 +70,39 @@ jobs:
           chmod +x gradlew
           ./gradlew bootJar
 
-      - name: DockerHub 로그인
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Docker 이미지 빌드
-        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.APP_NAME }}:latest .
+      - name: Build Docker image
+        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/${APP_NAME}:latest .
 
-      - name: DockerHub 푸시
-        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.APP_NAME }}:latest
+      - name: Push to DockerHub
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${APP_NAME}:latest
+
+  deploy-app:
+    needs: cd
+    if: github.event_name == 'push'
+    runs-on: [self-hosted, was]
+
+    steps:
+      - name: Blue-Green deploy
+        run: ~/deploy/deploy.sh ${APP_NAME} ${{ secrets.DOCKERHUB_USERNAME }}
+
+      - name: Output active slot
+        id: slot
+        run: echo "active=$(cat ~/deploy/active-slot)" >> $GITHUB_OUTPUT
+
+    outputs:
+      active-slot: ${{ steps.slot.outputs.active }}
+
+  switch-nginx:
+    needs: deploy-app
+    if: github.event_name == 'push'
+    runs-on: [self-hosted, web]
+
+    steps:
+      - name: Switch Nginx upstream
+        run: ~/nginx/switch.sh ${{ needs.deploy-app.outputs.active-slot }}

--- a/src/main/java/com/backend/allreva/common/config/FcmInitializer.java
+++ b/src/main/java/com/backend/allreva/common/config/FcmInitializer.java
@@ -5,24 +5,48 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import javax.annotation.PostConstruct;
-import org.springframework.core.io.ClassPathResource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class FcmInitializer {
+
+    private static final List<String> FCM_SCOPES =
+            List.of("https://www.googleapis.com/auth/firebase.messaging");
+
+    private final ResourceLoader resourceLoader;
+
+    @Value("${fcm.service-account-key}")
+    private String serviceAccountKeyPath;
+
+    private GoogleCredentials credentials;
 
     @PostConstruct
     public void initialize() {
-        try (InputStream serviceAccount =
-                new ClassPathResource("firebase/firebase-service-account-key.json").getInputStream()) {
+        Resource resource = resourceLoader.getResource(serviceAccountKeyPath);
+        try (InputStream serviceAccount = resource.getInputStream()) {
+            credentials = GoogleCredentials.fromStream(serviceAccount)
+                    .createScoped(FCM_SCOPES);
+
             FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .setCredentials(credentials)
                     .build();
             FirebaseApp.initializeApp(options);
+            log.info("Firebase initialized - key: {}", serviceAccountKeyPath);
         } catch (IOException e) {
-            e.printStackTrace();
             throw new RuntimeException("Failed to initialize Firebase", e);
         }
+    }
+
+    public GoogleCredentials getCredentials() {
+        return credentials;
     }
 }

--- a/src/main/java/com/backend/allreva/common/config/FcmInitializer.java
+++ b/src/main/java/com/backend/allreva/common/config/FcmInitializer.java
@@ -19,8 +19,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class FcmInitializer {
 
-    private static final List<String> FCM_SCOPES =
-            List.of("https://www.googleapis.com/auth/firebase.messaging");
+    private static final List<String> FCM_SCOPES = List.of("https://www.googleapis.com/auth/firebase.messaging");
 
     private final ResourceLoader resourceLoader;
 
@@ -33,12 +32,10 @@ public class FcmInitializer {
     public void initialize() {
         Resource resource = resourceLoader.getResource(serviceAccountKeyPath);
         try (InputStream serviceAccount = resource.getInputStream()) {
-            credentials = GoogleCredentials.fromStream(serviceAccount)
-                    .createScoped(FCM_SCOPES);
+            credentials = GoogleCredentials.fromStream(serviceAccount).createScoped(FCM_SCOPES);
 
-            FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(credentials)
-                    .build();
+            FirebaseOptions options =
+                    FirebaseOptions.builder().setCredentials(credentials).build();
             FirebaseApp.initializeApp(options);
             log.info("Firebase initialized - key: {}", serviceAccountKeyPath);
         } catch (IOException e) {

--- a/src/main/java/com/backend/allreva/module/notification/infra/fcm/FcmSender.java
+++ b/src/main/java/com/backend/allreva/module/notification/infra/fcm/FcmSender.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class FcmSender implements NotificationSender {
 
     private final FcmClient fcmClient;
+    private final FcmTokenUtils fcmTokenUtils;
 
     @Value("${fcm.project-id}")
     private String projectId;
@@ -22,20 +23,18 @@ public class FcmSender implements NotificationSender {
     @Override
     public void sendMessage(final String target, final String title, final String message) {
         try {
-            String accessToken = FcmTokenUtils.getAccessToken();
+            String accessToken = fcmTokenUtils.getAccessToken();
             String authorizationHeader = "Bearer " + accessToken;
             FcmMessage fcmMessage = FcmMessage.from(target, false, title, message);
 
             fcmClient.sendMessage(authorizationHeader, fcmMessage, projectId);
 
-            log.debug("FCM 메시지 전송 성공 - title: {}", title);
+            log.debug("FCM message sent successfully - title: {}", title);
         } catch (CustomException e) {
-            // FcmTokenUtils에서 발생한 토큰 발급 실패
-            log.warn("FCM 토큰 발급 실패로 메시지 전송 불가 - title: {}", title);
+            log.warn("FCM message send failed due to token issue - title: {}", title);
             throw e;
         } catch (FeignException e) {
-            // FCM API 호출 실패
-            log.error("FCM API 호출 실패 - status: {}, title: {}", e.status(), title, e);
+            log.error("FCM API call failed - status: {}, title: {}", e.status(), title, e);
             throw new CustomException(NotificationErrorCode.FCM_SEND_FAILED, e);
         }
     }

--- a/src/main/java/com/backend/allreva/module/notification/infra/fcm/FcmTokenUtils.java
+++ b/src/main/java/com/backend/allreva/module/notification/infra/fcm/FcmTokenUtils.java
@@ -1,56 +1,44 @@
 package com.backend.allreva.module.notification.infra.fcm;
 
+import com.backend.allreva.common.config.FcmInitializer;
 import com.backend.allreva.common.exception.CustomException;
 import com.backend.allreva.module.notification.exception.NotificationErrorCode;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Instant;
-import java.util.List;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
 
 @Slf4j
-@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
-public final class FcmTokenUtils {
+@Component
+@RequiredArgsConstructor
+public class FcmTokenUtils {
 
-    private static final String KEY_PATH = "firebase/firebase-service-account.json";
-    private static final GoogleCredentials googleCredentials;
-    private static AccessToken accessToken;
+    private final FcmInitializer fcmInitializer;
+    private AccessToken accessToken;
 
-    static {
-        try (InputStream serviceAccount = new ClassPathResource(KEY_PATH).getInputStream()) {
-            googleCredentials = GoogleCredentials.fromStream(serviceAccount)
-                    .createScoped(List.of("https://www.googleapis.com/auth/firebase.messaging"));
-        } catch (IOException e) {
-            log.error("Firebase 인증 정보 초기화 실패 - 서비스 계정 키 파일을 확인하세요: {}", KEY_PATH, e);
-            throw new RuntimeException("Failed to initialize GoogleCredentials", e);
-        }
-    }
-
-    public static String getAccessToken() {
+    public String getAccessToken() {
         try {
-            // 기존 캐시된 토큰이 존재하고, 만료되지 않았다면 재사용
             if (accessToken != null && !isTokenExpired(accessToken)) {
-                log.debug("기존 FCM 엑세스 토큰 재사용. 만료 시간: {}", accessToken.getExpirationTime());
+                log.debug("Reusing cached FCM access token. expires: {}", accessToken.getExpirationTime());
                 return accessToken.getTokenValue();
             }
 
-            // 토큰 갱신
-            googleCredentials.refreshIfExpired();
-            accessToken = googleCredentials.getAccessToken();
-            log.info("새 FCM 엑세스 토큰 발급 완료. 만료 시간: {}", accessToken.getExpirationTime());
+            GoogleCredentials credentials = fcmInitializer.getCredentials();
+            credentials.refreshIfExpired();
+            accessToken = credentials.getAccessToken();
+            log.info("New FCM access token issued. expires: {}", accessToken.getExpirationTime());
             return accessToken.getTokenValue();
 
         } catch (IOException e) {
-            log.error("FCM 엑세스 토큰 발급 실패 - Google OAuth2 토큰 갱신 실패", e);
+            log.error("Failed to issue FCM access token - Google OAuth2 token refresh failed", e);
             throw new CustomException(NotificationErrorCode.FCM_TOKEN_GENERATION_FAILED, e);
         }
     }
 
-    private static boolean isTokenExpired(AccessToken token) {
+    private boolean isTokenExpired(AccessToken token) {
         return token.getExpirationTime().toInstant().isBefore(Instant.now());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -97,3 +97,4 @@ spotify:
 
 fcm:
   project-id: ${FCM_PROJECT_ID}
+  service-account-key: classpath:firebase/firebase-service-account-key.json

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -90,3 +90,4 @@ spotify:
 
 fcm:
   project-id: test-fcm-project-id
+  service-account-key: classpath:firebase/firebase-service-account-key.json


### PR DESCRIPTION
### 연결된 issue 🌟
없음

### 구현 내용 📢
- Firebase 서비스 계정 경로를 property(`fcm.service-account-key`)로 분리하여 환경별 경로 주입 가능하도록 리팩토링
- FcmTokenUtils를 static 유틸에서 Spring Bean으로 전환, credentials 중복 로딩 제거
- Self-hosted runner(was, web 라벨) 기반 Blue-Green 무중단 배포 파이프라인 추가

### 테스트 결과 🧩
- VM에 Self-hosted runner 설치 및 데몬 등록 완료
- CI 파이프라인 정상 동작 확인 필요
- VM 배포 스크립트 구성 완료 및 CD 파이프라인 테스트 필요

### 리뷰 포인트 📌
ex) 중점으로 봐야할만한 포인트나, 논의 하고 싶은 포인트가 있다면 적어주세요!
