### PR TITLE
[Fix] Recruitment 모듈 결함 수정 및 통합 테스트 추가

### DIFF
--- a/src/main/java/com/backend/allreva/module/recruitment/rent/application/RentService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/application/RentService.java
@@ -50,7 +50,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class RentService {
 
     private final RentRepository rentRepository;
@@ -62,9 +61,19 @@ public class RentService {
     // Command
     // -------------------------
 
+    @Transactional
     public Long registerRent(final RentRegisterRequest request, final Long memberId) {
         Rent rent = request.toEntity(memberId);
         Rent savedRent = rentRepository.save(rent);
+
+        List<RentBoardingSlot> slots = request.rentBoardingDateRequests().stream()
+                .map(date -> RentBoardingSlot.builder()
+                        .rentId(savedRent.getId())
+                        .date(date)
+                        .recruitmentCount(request.recruitmentCount())
+                        .build())
+                .toList();
+        slots.forEach(rentBoardingSlotRepository::save);
 
         Events.raise(NotificationEvent.builder()
                 .type(NotificationType.RENT_REGISTERED)
@@ -78,6 +87,7 @@ public class RentService {
         return savedRent.getId();
     }
 
+    @Transactional
     public void updateRent(final RentUpdateRequest request, final Long memberId) {
         Rent rent = rentRepository
                 .findById(request.rentId())
@@ -116,8 +126,19 @@ public class RentService {
                 request.refundType(),
                 request.information(),
                 newBoardingInfos);
+
+        rentBoardingSlotRepository.deleteAllByRentId(request.rentId());
+        List<RentBoardingSlot> newSlots = request.rentBoardingDateRequests().stream()
+                .map(date -> RentBoardingSlot.builder()
+                        .rentId(request.rentId())
+                        .date(date)
+                        .recruitmentCount(request.recruitmentCount())
+                        .build())
+                .toList();
+        newSlots.forEach(rentBoardingSlotRepository::save);
     }
 
+    @Transactional
     public void closeRent(final RentIdRequest request, final Long memberId) {
         Rent rent = rentRepository
                 .findById(request.rentId())
@@ -138,6 +159,7 @@ public class RentService {
         rent.close();
     }
 
+    @Transactional
     public void deleteRent(final RentIdRequest request, final Long memberId) {
         Rent rent = rentRepository
                 .findById(request.rentId())
@@ -153,6 +175,7 @@ public class RentService {
     // Participant Command
     // -------------------------
 
+    @Transactional
     public Long applyRent(final RentJoinRequest request, final Long memberId) {
         if (rentParticipantRepository.exists(memberId, request.rentId(), request.boardingDate())) {
             throw new CustomException(RentErrorCode.RENT_JOIN_ALREADY_EXISTS);
@@ -168,6 +191,7 @@ public class RentService {
         return saved.getId();
     }
 
+    @Transactional
     public void updateRentJoin(final RentJoinUpdateRequest request, final Long memberId) {
         RentParticipant participant = rentParticipantRepository
                 .findById(request.rentParticipantId())
@@ -188,6 +212,7 @@ public class RentService {
                 request.boardingDate());
     }
 
+    @Transactional
     public void cancelRentJoin(final RentJoinIdRequest request, final Long memberId) {
         RentParticipant participant = rentParticipantRepository
                 .findById(request.rentParticipantId())

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/infra/RentRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/infra/RentRepositoryImpl.java
@@ -16,7 +16,6 @@ import com.backend.allreva.module.recruitment.rent.domain.RentRepository;
 import com.backend.allreva.module.recruitment.rent.domain.value.Region;
 import com.backend.allreva.module.recruitment.rent.infra.jpa.RentBoardingInfoJpaRepository;
 import com.backend.allreva.module.recruitment.rent.infra.jpa.RentJpaRepository;
-import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -120,8 +119,30 @@ public class RentRepositoryImpl implements RentRepository {
 
     @Override
     public Optional<RentDetailResponse> findRentDetail(final Long rentId) {
-        return Optional.ofNullable(queryFactory
-                .select(rentDetailProjections())
+        // Step 1: Fetch rent basic info including recruitmentCount from first boarding info
+        var tuple = queryFactory
+                .select(
+                        concert.concertInfo.title,
+                        rent.image.url,
+                        rent.title,
+                        rent.artistName,
+                        rent.region,
+                        rent.boardingArea,
+                        concertHall.name,
+                        rent.upTime,
+                        rent.downTime,
+                        rent.bus.busSize,
+                        rent.bus.busType,
+                        rent.bus.maxPassenger,
+                        rent.price.roundPrice,
+                        rent.price.upTimePrice,
+                        rent.price.downTimePrice,
+                        rentBoardingInfo.recruitmentCount,
+                        rent.endDate,
+                        rent.chatUrl,
+                        rent.refundType,
+                        rent.information,
+                        rent.isClosed)
                 .from(rent)
                 .join(rentBoardingInfo)
                 .on(rent.id.eq(rentBoardingInfo.rent.id))
@@ -130,35 +151,44 @@ public class RentRepositoryImpl implements RentRepository {
                 .leftJoin(concertHall)
                 .on(concert.code.hallCode.eq(concertHall.id))
                 .where(rent.id.eq(rentId))
-                .fetchFirst());
-    }
+                .fetchFirst();
 
-    private ConstructorExpression<RentDetailResponse> rentDetailProjections() {
-        return Projections.constructor(
-                RentDetailResponse.class,
-                concert.concertInfo.title,
-                rent.image.url,
-                rent.title,
-                rent.artistName,
-                rent.region,
-                rent.boardingArea,
-                concertHall.name,
-                rent.upTime,
-                rent.downTime,
-                Projections.list(Projections.constructor(
-                        RentBoardingDateResponse.class, rentBoardingInfo.date, rentBoardingInfo.passengerCount)),
-                rent.bus.busSize,
-                rent.bus.busType,
-                rent.bus.maxPassenger,
-                rent.price.roundPrice,
-                rent.price.upTimePrice,
-                rent.price.downTimePrice,
-                rentBoardingInfo.recruitmentCount,
-                rent.endDate,
-                rent.chatUrl,
-                rent.refundType,
-                rent.information,
-                rent.isClosed);
+        if (tuple == null) {
+            return Optional.empty();
+        }
+
+        // Step 2: Fetch all boarding dates separately to avoid fetchFirst limitation with 1:N
+        List<RentBoardingDateResponse> boardingDates = queryFactory
+                .select(Projections.constructor(
+                        RentBoardingDateResponse.class, rentBoardingInfo.date, rentBoardingInfo.passengerCount))
+                .from(rentBoardingInfo)
+                .where(rentBoardingInfo.rent.id.eq(rentId))
+                .orderBy(rentBoardingInfo.date.asc())
+                .fetch();
+
+        return Optional.of(new RentDetailResponse(
+                tuple.get(concert.concertInfo.title),
+                tuple.get(rent.image.url),
+                tuple.get(rent.title),
+                tuple.get(rent.artistName),
+                tuple.get(rent.region),
+                tuple.get(rent.boardingArea),
+                tuple.get(concertHall.name),
+                tuple.get(rent.upTime),
+                tuple.get(rent.downTime),
+                boardingDates,
+                tuple.get(rent.bus.busSize),
+                tuple.get(rent.bus.busType),
+                tuple.get(rent.bus.maxPassenger),
+                tuple.get(rent.price.roundPrice),
+                tuple.get(rent.price.upTimePrice),
+                tuple.get(rent.price.downTimePrice),
+                tuple.get(rentBoardingInfo.recruitmentCount),
+                tuple.get(rent.endDate),
+                tuple.get(rent.chatUrl),
+                tuple.get(rent.refundType),
+                tuple.get(rent.information),
+                tuple.get(rent.isClosed)));
     }
 
     private BooleanExpression getRegionCondition(final Region region) {

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/application/SurveyService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/application/SurveyService.java
@@ -33,7 +33,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class SurveyService {
 
@@ -42,6 +41,7 @@ public class SurveyService {
     private final ConcertRepository concertRepository;
 
     /** 수요조사 개설 */
+    @Transactional
     public Long openSurvey(final Long memberId, final OpenSurveyRequest request) {
         validateBoardingDates(request.concertId(), request.boardingDates());
 
@@ -70,6 +70,7 @@ public class SurveyService {
     }
 
     /** 수요조사 수정 */
+    @Transactional
     public void updateSurvey(final Long memberId, final UpdateSurveyRequest request) {
         Survey survey = findSurvey(request.surveyId());
 
@@ -86,6 +87,7 @@ public class SurveyService {
     }
 
     /** 수요조사 삭제 */
+    @Transactional
     public void removeSurvey(final Long memberId, final SurveyIdRequest surveyIdRequest) {
         Survey survey = findSurvey(surveyIdRequest.surveyId());
         survey.isWriter(memberId);
@@ -93,7 +95,12 @@ public class SurveyService {
     }
 
     /** 수요조사 참여 (응답 제출) */
+    @Transactional
     public Long joinSurvey(final Long memberId, final JoinSurveyRequest request) {
+        if (surveyParticipantRepository.existsByMemberIdAndSurveyId(memberId, request.surveyId())) {
+            throw new CustomException(SurveyErrorCode.SURVEY_JOIN_ALREADY_EXISTS);
+        }
+
         Survey survey = findSurvey(request.surveyId());
         survey.containsBoardingDate(request.boardingDate());
 
@@ -110,10 +117,14 @@ public class SurveyService {
     }
 
     /** 수요조사 참여 취소 */
+    @Transactional
     public void cancelJoin(final Long memberId, final Long participantId) {
         SurveyParticipant participant = surveyParticipantRepository
                 .findById(participantId)
                 .orElseThrow(() -> new CustomException(SurveyErrorCode.SURVEY_PARTICIPANT_NOT_FOUND));
+        if (!participant.getMemberId().equals(memberId)) {
+            throw new CustomException(SurveyErrorCode.SURVEY_JOIN_ACCESS_DENIED);
+        }
         surveyParticipantRepository.delete(participant);
     }
 

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/domain/participant/SurveyParticipantRepository.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/domain/participant/SurveyParticipantRepository.java
@@ -18,4 +18,6 @@ public interface SurveyParticipantRepository {
             Long memberId, Long lastId, LocalDate lastBoardingDate, int pageSize);
 
     List<JoinSurveyResponse> findJoinSurveyList(Long memberId, Long lastId, int pageSize);
+
+    boolean existsByMemberIdAndSurveyId(Long memberId, Long surveyId);
 }

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/exception/SurveyErrorCode.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/exception/SurveyErrorCode.java
@@ -17,7 +17,9 @@ public enum SurveyErrorCode implements ErrorCode {
     SURVEY_EVENT_PUBLISHING_FAIL(
             HttpStatus.INTERNAL_SERVER_ERROR.value(), "SURVEY_EVENT_PUBLISHING_FAIL", "survey event 발행 실패"),
     SURVEY_EVENT_CONSUMING_FAIL(
-            HttpStatus.INTERNAL_SERVER_ERROR.value(), "SURVEY_EVENT_CONSUMING_FAIL", "survey event 소비 실패");
+            HttpStatus.INTERNAL_SERVER_ERROR.value(), "SURVEY_EVENT_CONSUMING_FAIL", "survey event 소비 실패"),
+    SURVEY_JOIN_ALREADY_EXISTS(HttpStatus.BAD_REQUEST.value(), "SURVEY_JOIN_ALREADY_EXISTS", "이미 해당 수요조사에 참여했습니다."),
+    SURVEY_JOIN_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "SURVEY_JOIN_ACCESS_DENIED", "수요조사 참여에 대한 접근 권한이 없습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/infra/SurveyParticipantRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/infra/SurveyParticipantRepositoryImpl.java
@@ -142,6 +142,11 @@ public class SurveyParticipantRepositoryImpl implements SurveyParticipantReposit
                 "participationCount");
     }
 
+    @Override
+    public boolean existsByMemberIdAndSurveyId(final Long memberId, final Long surveyId) {
+        return surveyParticipantJpaRepository.existsByMemberIdAndSurveyId(memberId, surveyId);
+    }
+
     private BooleanExpression getJoinSurveyPagingCondition(final Long lastId) {
         if (lastId == null) {
             return null;

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/infra/jpa/SurveyParticipantJpaRepository.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/infra/jpa/SurveyParticipantJpaRepository.java
@@ -3,4 +3,7 @@ package com.backend.allreva.module.recruitment.survey.infra.jpa;
 import com.backend.allreva.module.recruitment.survey.domain.participant.SurveyParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SurveyParticipantJpaRepository extends JpaRepository<SurveyParticipant, Long> {}
+public interface SurveyParticipantJpaRepository extends JpaRepository<SurveyParticipant, Long> {
+
+    boolean existsByMemberIdAndSurveyId(Long memberId, Long surveyId);
+}

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/fixture/RentFixture.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/fixture/RentFixture.java
@@ -1,0 +1,85 @@
+package com.backend.allreva.module.recruitment.rent.fixture;
+
+import com.backend.allreva.common.model.Image;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentIdRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentRegisterRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentUpdateRequest;
+import com.backend.allreva.module.recruitment.rent.domain.value.BoardingType;
+import com.backend.allreva.module.recruitment.rent.domain.value.BusSize;
+import com.backend.allreva.module.recruitment.rent.domain.value.BusType;
+import com.backend.allreva.module.recruitment.rent.domain.value.RefundType;
+import com.backend.allreva.module.recruitment.rent.domain.value.Region;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RentFixture {
+
+    public static RentRegisterRequest createRentRegisterRequest(Long concertId, List<LocalDate> dates) {
+        return new RentRegisterRequest(
+                concertId,
+                "테스트 차대절",
+                "테스트 아티스트",
+                Region.서울,
+                "국민은행 12345",
+                "서울역 앞",
+                "10:00",
+                "22:00",
+                dates,
+                BusSize.LARGE,
+                BusType.STANDARD,
+                45,
+                50000,
+                30000,
+                20000,
+                30,
+                LocalDate.of(2030, 11, 30),
+                "https://chat.example.com",
+                RefundType.REFUND,
+                "테스트 차대절 정보",
+                new Image("https://example.com/rent.jpg"));
+    }
+
+    public static RentUpdateRequest createRentUpdateRequest(Long rentId, List<LocalDate> dates) {
+        return new RentUpdateRequest(
+                rentId,
+                Region.서울,
+                "부산역 앞",
+                "09:00",
+                "23:00",
+                dates,
+                BusSize.MEDIUM,
+                BusType.DELUXE,
+                40,
+                60000,
+                35000,
+                25000,
+                20,
+                LocalDate.of(2030, 11, 30),
+                "https://chat.example.com",
+                RefundType.REFUND,
+                "수정된 차대절 정보",
+                new Image("https://example.com/rent-updated.jpg"));
+    }
+
+    public static RentIdRequest createRentIdRequest(Long rentId) {
+        return new RentIdRequest(rentId);
+    }
+
+    public static RentJoinRequest createRentJoinRequest(Long rentId, LocalDate date, int passengerNum) {
+        return RentJoinRequest.builder()
+                .rentId(rentId)
+                .boardingDate(date)
+                .boardingType(BoardingType.ROUND)
+                .passengerNum(passengerNum)
+                .depositorName("홍길동")
+                .depositorTime("12:00")
+                .phone("010-1234-5678")
+                .refundType(RefundType.REFUND)
+                .refundAccount("국민은행 99999")
+                .build();
+    }
+}

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentIntegrationTest.java
@@ -1,0 +1,434 @@
+package com.backend.allreva.module.recruitment.rent.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+import com.backend.allreva.common.exception.CustomException;
+import com.backend.allreva.common.storage.upload.StorageUploadService;
+import com.backend.allreva.module.concert.concert.domain.Concert;
+import com.backend.allreva.module.concert.concert.fixture.ConcertFixture;
+import com.backend.allreva.module.concert.concert.infra.jpa.ConcertJpaRepository;
+import com.backend.allreva.module.member.domain.Member;
+import com.backend.allreva.module.member.domain.MemberRepository;
+import com.backend.allreva.module.member.fixture.MemberFixture;
+import com.backend.allreva.module.recruitment.rent.application.RentService;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentDetailResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentSummaryResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.SortType;
+import com.backend.allreva.module.recruitment.rent.domain.RentBoardingSlotRepository;
+import com.backend.allreva.module.recruitment.rent.domain.RentRepository;
+import com.backend.allreva.module.recruitment.rent.domain.participant.RentParticipantRepository;
+import com.backend.allreva.module.recruitment.rent.exception.RentErrorCode;
+import com.backend.allreva.module.recruitment.rent.fixture.RentFixture;
+import com.backend.allreva.module.recruitment.rent.infra.jpa.RentBoardingInfoJpaRepository;
+import com.backend.allreva.module.recruitment.rent.infra.jpa.RentBoardingSlotJpaRepository;
+import com.backend.allreva.module.recruitment.rent.infra.jpa.RentJpaRepository;
+import com.backend.allreva.module.recruitment.rent.infra.jpa.RentParticipantJpaRepository;
+import com.backend.allreva.support.IntegrationTestSupport;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@DisplayName("Rent Integration 테스트")
+class RentIntegrationTest extends IntegrationTestSupport {
+
+    private static final List<LocalDate> BOARDING_DATES = List.of(LocalDate.of(2030, 12, 1), LocalDate.of(2030, 12, 2));
+
+    @Autowired
+    private RentService rentService;
+
+    @Autowired
+    private RentRepository rentRepository;
+
+    @Autowired
+    private RentBoardingSlotRepository rentBoardingSlotRepository;
+
+    @Autowired
+    private RentParticipantRepository rentParticipantRepository;
+
+    @Autowired
+    private RentJpaRepository rentJpaRepository;
+
+    @Autowired
+    private RentBoardingInfoJpaRepository rentBoardingInfoJpaRepository;
+
+    @Autowired
+    private RentBoardingSlotJpaRepository rentBoardingSlotJpaRepository;
+
+    @Autowired
+    private RentParticipantJpaRepository rentParticipantJpaRepository;
+
+    @Autowired
+    private ConcertJpaRepository concertJpaRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private StorageUploadService storageUploadService;
+
+    private Member savedMember;
+    private Long concertId;
+
+    @BeforeEach
+    void setUp() {
+        savedMember = memberRepository.save(MemberFixture.createTestMember());
+        Concert concert = concertJpaRepository.save(ConcertFixture.createTestConcert());
+        concertId = concert.getId();
+        doNothing().when(storageUploadService).deleteImage(any());
+    }
+
+    @AfterEach
+    void tearDown() {
+        rentParticipantJpaRepository.deleteAll();
+        rentBoardingSlotJpaRepository.deleteAll();
+        rentBoardingInfoJpaRepository.deleteAll();
+        rentJpaRepository.deleteAll();
+        concertJpaRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("registerRent 테스트")
+    class Describe_registerRent {
+
+        @Nested
+        @DisplayName("유효한 요청으로 차대절 등록 시")
+        class Context_valid_request {
+
+            private Long savedRentId;
+
+            @BeforeEach
+            void setUp() {
+                savedRentId = rentService.registerRent(
+                        RentFixture.createRentRegisterRequest(concertId, BOARDING_DATES), savedMember.getId());
+            }
+
+            @Test
+            @DisplayName("차대절이 저장된다")
+            void it_saves_rent() {
+                var rent = rentRepository.findById(savedRentId).orElseThrow();
+                assertThat(rent.getTitle()).isEqualTo("테스트 차대절");
+                assertThat(rent.getMemberId()).isEqualTo(savedMember.getId());
+                assertThat(rent.getConcertId()).isEqualTo(concertId);
+            }
+
+            @Test
+            @DisplayName("탑승 날짜 정보가 저장된다")
+            void it_saves_boarding_infos() {
+                var infos = rentBoardingInfoJpaRepository.findAll().stream()
+                        .filter(info -> info.getRent().getId().equals(savedRentId))
+                        .toList();
+                assertThat(infos).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("탑승 슬롯이 생성된다")
+            void it_creates_boarding_slots() {
+                var slots = rentBoardingSlotRepository.findAllByRentId(savedRentId);
+                assertThat(slots).hasSize(2);
+                slots.forEach(slot -> {
+                    assertThat(slot.getRecruitmentCount()).isEqualTo(30);
+                    assertThat(slot.getPassengerCount()).isEqualTo(0);
+                });
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateRent 테스트")
+    class Describe_updateRent {
+
+        private Long savedRentId;
+
+        @BeforeEach
+        void setUp() {
+            savedRentId = rentService.registerRent(
+                    RentFixture.createRentRegisterRequest(concertId, BOARDING_DATES), savedMember.getId());
+        }
+
+        @Nested
+        @DisplayName("본인 차대절 수정 시")
+        class Context_own_rent {
+
+            private static final List<LocalDate> NEW_DATES = List.of(LocalDate.of(2030, 12, 1));
+
+            @BeforeEach
+            void setUp() {
+                rentService.updateRent(
+                        RentFixture.createRentUpdateRequest(savedRentId, NEW_DATES), savedMember.getId());
+            }
+
+            @Test
+            @DisplayName("차대절 필드가 수정된다")
+            void it_updates_rent_fields() {
+                var rent = rentRepository.findById(savedRentId).orElseThrow();
+                assertThat(rent.getBoardingArea()).isEqualTo("부산역 앞");
+                assertThat(rent.getUpTime()).isEqualTo("09:00");
+            }
+
+            @Test
+            @DisplayName("탑승 날짜 정보가 교체된다")
+            void it_replaces_boarding_infos() {
+                var infos = rentBoardingInfoJpaRepository.findAll().stream()
+                        .filter(info -> info.getRent().getId().equals(savedRentId))
+                        .toList();
+                assertThat(infos).hasSize(1);
+                assertThat(infos.get(0).getDate()).isEqualTo(LocalDate.of(2030, 12, 1));
+            }
+
+            @Test
+            @DisplayName("탑승 슬롯이 동기화된다")
+            void it_syncs_boarding_slots() {
+                var slots = rentBoardingSlotRepository.findAllByRentId(savedRentId);
+                assertThat(slots).hasSize(1);
+                assertThat(slots.get(0).getDate()).isEqualTo(LocalDate.of(2030, 12, 1));
+                assertThat(slots.get(0).getRecruitmentCount()).isEqualTo(20);
+            }
+        }
+
+        @Nested
+        @DisplayName("타인의 차대절 수정 시")
+        class Context_other_member {
+
+            private Member otherMember;
+
+            @BeforeEach
+            void setUp() {
+                otherMember = memberRepository.save(MemberFixture.createTestMember());
+            }
+
+            @Test
+            @DisplayName("접근 거부 예외가 발생한다")
+            void it_throws_access_denied() {
+                assertThatThrownBy(() -> rentService.updateRent(
+                                RentFixture.createRentUpdateRequest(savedRentId, BOARDING_DATES), otherMember.getId()))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(RentErrorCode.RENT_ACCESS_DENIED.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("closeRent 테스트")
+    class Describe_closeRent {
+
+        private Long savedRentId;
+
+        @BeforeEach
+        void setUp() {
+            savedRentId = rentService.registerRent(
+                    RentFixture.createRentRegisterRequest(concertId, BOARDING_DATES), savedMember.getId());
+        }
+
+        @Nested
+        @DisplayName("본인 차대절 마감 시")
+        class Context_own_rent {
+
+            @Test
+            @DisplayName("차대절이 마감된다")
+            void it_closes_rent() {
+                rentService.closeRent(RentFixture.createRentIdRequest(savedRentId), savedMember.getId());
+                var rent = rentRepository.findById(savedRentId).orElseThrow();
+                assertThat(rent.isClosed()).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayName("타인의 차대절 마감 시")
+        class Context_other_member {
+
+            @Test
+            @DisplayName("접근 거부 예외가 발생한다")
+            void it_throws_access_denied() {
+                Member otherMember = memberRepository.save(MemberFixture.createTestMember());
+                assertThatThrownBy(() -> rentService.closeRent(
+                                RentFixture.createRentIdRequest(savedRentId), otherMember.getId()))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(RentErrorCode.RENT_ACCESS_DENIED.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteRent 테스트")
+    class Describe_deleteRent {
+
+        private Long savedRentId;
+
+        @BeforeEach
+        void setUp() {
+            savedRentId = rentService.registerRent(
+                    RentFixture.createRentRegisterRequest(concertId, BOARDING_DATES), savedMember.getId());
+        }
+
+        @Nested
+        @DisplayName("본인 차대절 삭제 시")
+        class Context_own_rent {
+
+            @Test
+            @DisplayName("차대절이 소프트 삭제된다")
+            void it_soft_deletes_rent() {
+                rentService.deleteRent(RentFixture.createRentIdRequest(savedRentId), savedMember.getId());
+                assertThat(rentRepository.findById(savedRentId)).isEmpty();
+            }
+
+            @Test
+            @DisplayName("이미지 삭제가 호출된다")
+            void it_deletes_image() {
+                rentService.deleteRent(RentFixture.createRentIdRequest(savedRentId), savedMember.getId());
+                verify(storageUploadService).deleteImage(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("타인의 차대절 삭제 시")
+        class Context_other_member {
+
+            @Test
+            @DisplayName("접근 거부 예외가 발생한다")
+            void it_throws_access_denied() {
+                Member otherMember = memberRepository.save(MemberFixture.createTestMember());
+                assertThatThrownBy(() -> rentService.deleteRent(
+                                RentFixture.createRentIdRequest(savedRentId), otherMember.getId()))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(RentErrorCode.RENT_ACCESS_DENIED.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("applyRent 테스트")
+    class Describe_applyRent {
+
+        private Long savedRentId;
+        private static final LocalDate TARGET_DATE = LocalDate.of(2030, 12, 1);
+
+        @BeforeEach
+        void setUp() {
+            savedRentId = rentService.registerRent(
+                    RentFixture.createRentRegisterRequest(concertId, BOARDING_DATES), savedMember.getId());
+        }
+
+        @Nested
+        @DisplayName("좌석이 남아 있는 경우")
+        class Context_seats_available {
+
+            @Test
+            @DisplayName("참여자가 저장된다")
+            void it_saves_participant() {
+                Long participantId = rentService.applyRent(
+                        RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 2), savedMember.getId());
+                assertThat(participantId).isNotNull();
+            }
+
+            @Test
+            @DisplayName("슬롯의 탑승 인원이 증가한다")
+            void it_increases_passenger_count() {
+                rentService.applyRent(
+                        RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 3), savedMember.getId());
+                var slot = rentBoardingSlotRepository
+                        .findByRentIdAndDate(savedRentId, TARGET_DATE)
+                        .orElseThrow();
+                assertThat(slot.getPassengerCount()).isEqualTo(3);
+            }
+        }
+
+        @Nested
+        @DisplayName("이미 신청한 경우")
+        class Context_already_applied {
+
+            @BeforeEach
+            void setUp() {
+                rentService.applyRent(
+                        RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 2), savedMember.getId());
+            }
+
+            @Test
+            @DisplayName("중복 신청 예외가 발생한다")
+            void it_throws_already_exists() {
+                assertThatThrownBy(() -> rentService.applyRent(
+                                RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 1), savedMember.getId()))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(RentErrorCode.RENT_JOIN_ALREADY_EXISTS.getMessage());
+            }
+        }
+
+        @Nested
+        @DisplayName("좌석이 초과된 경우")
+        class Context_seats_exceeded {
+
+            @Test
+            @DisplayName("슬롯 초과 예외가 발생한다")
+            void it_throws_slot_full() {
+                assertThatThrownBy(() -> rentService.applyRent(
+                                RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 31), savedMember.getId()))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(RentErrorCode.SLOT_FULL.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getRentDetail 테스트")
+    class Describe_getRentDetail {
+
+        private Long savedRentId;
+
+        @BeforeEach
+        void setUp() {
+            savedRentId = rentService.registerRent(
+                    RentFixture.createRentRegisterRequest(concertId, BOARDING_DATES), savedMember.getId());
+        }
+
+        @Nested
+        @DisplayName("여러 탑승 날짜가 있는 경우")
+        class Context_multiple_dates {
+
+            @Test
+            @DisplayName("모든 탑승 날짜가 반환된다")
+            void it_returns_all_boarding_dates() {
+                RentDetailResponse detail = rentService.getRentDetail(savedRentId, null);
+                assertThat(detail.getBoardingDates()).hasSize(2);
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 차대절 조회 시")
+        class Context_not_found {
+
+            @Test
+            @DisplayName("NOT_FOUND 예외가 발생한다")
+            void it_throws_not_found() {
+                assertThatThrownBy(() -> rentService.getRentDetail(999L, null))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(RentErrorCode.RENT_NOT_FOUND.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getRentSummaries 테스트")
+    class Describe_getRentSummaries {
+
+        @Test
+        @DisplayName("마감된 차대절은 목록에 포함되지 않는다")
+        void it_excludes_closed_rents() {
+            Long rentId = rentService.registerRent(
+                    RentFixture.createRentRegisterRequest(concertId, BOARDING_DATES), savedMember.getId());
+            rentService.closeRent(RentFixture.createRentIdRequest(rentId), savedMember.getId());
+
+            List<RentSummaryResponse> summaries = rentService.getRentSummaries(null, SortType.LATEST, null, null, 10);
+            assertThat(summaries).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/backend/allreva/module/recruitment/survey/fixture/SurveyFixture.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/survey/fixture/SurveyFixture.java
@@ -1,0 +1,34 @@
+package com.backend.allreva.module.recruitment.survey.fixture;
+
+import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyRequest;
+import com.backend.allreva.module.recruitment.survey.application.dto.OpenSurveyRequest;
+import com.backend.allreva.module.recruitment.survey.application.dto.SurveyIdRequest;
+import com.backend.allreva.module.recruitment.survey.application.dto.UpdateSurveyRequest;
+import com.backend.allreva.module.recruitment.survey.domain.value.BoardingType;
+import com.backend.allreva.module.recruitment.survey.domain.value.Region;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SurveyFixture {
+
+    public static OpenSurveyRequest createOpenSurveyRequest(Long concertId, List<LocalDate> dates) {
+        return new OpenSurveyRequest(
+                "테스트 수요조사", concertId, dates, "테스트 아티스트", Region.서울, LocalDate.of(2030, 11, 30), 45, "테스트 수요조사 정보");
+    }
+
+    public static UpdateSurveyRequest createUpdateSurveyRequest(Long surveyId, List<LocalDate> dates) {
+        return new UpdateSurveyRequest(
+                surveyId, "수정된 수요조사", dates, Region.서울, LocalDate.of(2030, 11, 30), 30, "수정된 정보");
+    }
+
+    public static SurveyIdRequest createSurveyIdRequest(Long surveyId) {
+        return new SurveyIdRequest(surveyId);
+    }
+
+    public static JoinSurveyRequest createJoinSurveyRequest(Long surveyId, LocalDate boardingDate) {
+        return new JoinSurveyRequest(surveyId, boardingDate, BoardingType.ROUND, 2, false);
+    }
+}

--- a/src/test/java/com/backend/allreva/module/recruitment/survey/integration/SurveyIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/survey/integration/SurveyIntegrationTest.java
@@ -1,0 +1,374 @@
+package com.backend.allreva.module.recruitment.survey.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.backend.allreva.common.exception.CustomException;
+import com.backend.allreva.module.concert.concert.domain.Concert;
+import com.backend.allreva.module.concert.concert.fixture.ConcertFixture;
+import com.backend.allreva.module.concert.concert.infra.jpa.ConcertJpaRepository;
+import com.backend.allreva.module.member.domain.Member;
+import com.backend.allreva.module.member.domain.MemberRepository;
+import com.backend.allreva.module.member.fixture.MemberFixture;
+import com.backend.allreva.module.recruitment.survey.application.SurveyService;
+import com.backend.allreva.module.recruitment.survey.application.dto.SortType;
+import com.backend.allreva.module.recruitment.survey.application.dto.SurveyDetailResponse;
+import com.backend.allreva.module.recruitment.survey.application.dto.SurveySummaryResponse;
+import com.backend.allreva.module.recruitment.survey.domain.SurveyRepository;
+import com.backend.allreva.module.recruitment.survey.domain.participant.SurveyParticipantRepository;
+import com.backend.allreva.module.recruitment.survey.domain.value.Region;
+import com.backend.allreva.module.recruitment.survey.exception.SurveyErrorCode;
+import com.backend.allreva.module.recruitment.survey.fixture.SurveyFixture;
+import com.backend.allreva.module.recruitment.survey.infra.jpa.SurveyJpaRepository;
+import com.backend.allreva.module.recruitment.survey.infra.jpa.SurveyParticipantJpaRepository;
+import com.backend.allreva.support.IntegrationTestSupport;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("Survey Integration 테스트")
+class SurveyIntegrationTest extends IntegrationTestSupport {
+
+    private static final List<LocalDate> BOARDING_DATES = List.of(LocalDate.of(2030, 12, 1), LocalDate.of(2030, 12, 2));
+
+    @Autowired
+    private SurveyService surveyService;
+
+    @Autowired
+    private SurveyRepository surveyRepository;
+
+    @Autowired
+    private SurveyParticipantRepository surveyParticipantRepository;
+
+    @Autowired
+    private SurveyJpaRepository surveyJpaRepository;
+
+    @Autowired
+    private SurveyParticipantJpaRepository surveyParticipantJpaRepository;
+
+    @Autowired
+    private ConcertJpaRepository concertJpaRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member savedMember;
+    private Long concertId;
+
+    @BeforeEach
+    void setUp() {
+        savedMember = memberRepository.save(MemberFixture.createTestMember());
+        Concert concert = concertJpaRepository.save(ConcertFixture.createTestConcert());
+        concertId = concert.getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        surveyParticipantJpaRepository.deleteAll();
+        surveyJpaRepository.deleteAll();
+        concertJpaRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("openSurvey 테스트")
+    class Describe_openSurvey {
+
+        @Nested
+        @DisplayName("유효한 요청으로 수요조사 개설 시")
+        class Context_valid_request {
+
+            private Long savedSurveyId;
+
+            @BeforeEach
+            void setUp() {
+                savedSurveyId = surveyService.openSurvey(
+                        savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertId, BOARDING_DATES));
+            }
+
+            @Test
+            @DisplayName("수요조사가 저장된다")
+            void it_saves_survey() {
+                var survey = surveyRepository.findById(savedSurveyId).orElseThrow();
+                assertThat(survey.getTitle()).isEqualTo("테스트 수요조사");
+            }
+
+            @Test
+            @DisplayName("탑승 날짜가 JSONB로 저장된다")
+            void it_saves_boarding_dates_as_jsonb() {
+                var survey = surveyRepository.findById(savedSurveyId).orElseThrow();
+                assertThat(survey.getBoardingDates()).hasSize(2);
+                assertThat(survey.getBoardingDates()).containsAll(BOARDING_DATES);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateSurvey 테스트")
+    class Describe_updateSurvey {
+
+        private Long savedSurveyId;
+
+        @BeforeEach
+        void setUp() {
+            savedSurveyId = surveyService.openSurvey(
+                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertId, BOARDING_DATES));
+        }
+
+        @Nested
+        @DisplayName("본인 수요조사 수정 시")
+        class Context_own_survey {
+
+            @Test
+            @DisplayName("수요조사가 수정된다")
+            void it_updates_survey() {
+                surveyService.updateSurvey(
+                        savedMember.getId(), SurveyFixture.createUpdateSurveyRequest(savedSurveyId, BOARDING_DATES));
+                var survey = surveyRepository.findById(savedSurveyId).orElseThrow();
+                assertThat(survey.getTitle()).isEqualTo("수정된 수요조사");
+            }
+        }
+
+        @Nested
+        @DisplayName("타인의 수요조사 수정 시")
+        class Context_other_member {
+
+            @Test
+            @DisplayName("접근 거부 예외가 발생한다")
+            void it_throws_access_denied() {
+                Member otherMember = memberRepository.save(MemberFixture.createTestMember());
+                assertThatThrownBy(() -> surveyService.updateSurvey(
+                                otherMember.getId(),
+                                SurveyFixture.createUpdateSurveyRequest(savedSurveyId, BOARDING_DATES)))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(SurveyErrorCode.SURVEY_NOT_WRITER.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("removeSurvey 테스트")
+    class Describe_deleteSurvey {
+
+        private Long savedSurveyId;
+
+        @BeforeEach
+        void setUp() {
+            savedSurveyId = surveyService.openSurvey(
+                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertId, BOARDING_DATES));
+        }
+
+        @Nested
+        @DisplayName("본인 수요조사 삭제 시")
+        class Context_own_survey {
+
+            @Test
+            @DisplayName("수요조사가 소프트 삭제된다")
+            void it_soft_deletes_survey() {
+                surveyService.removeSurvey(savedMember.getId(), SurveyFixture.createSurveyIdRequest(savedSurveyId));
+                assertThat(surveyRepository.findById(savedSurveyId)).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("타인의 수요조사 삭제 시")
+        class Context_other_member {
+
+            @Test
+            @DisplayName("접근 거부 예외가 발생한다")
+            void it_throws_access_denied() {
+                Member otherMember = memberRepository.save(MemberFixture.createTestMember());
+                assertThatThrownBy(() -> surveyService.removeSurvey(
+                                otherMember.getId(), SurveyFixture.createSurveyIdRequest(savedSurveyId)))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(SurveyErrorCode.SURVEY_NOT_WRITER.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("joinSurvey 테스트")
+    class Describe_joinSurvey {
+
+        private Long savedSurveyId;
+        private static final LocalDate TARGET_DATE = LocalDate.of(2030, 12, 1);
+
+        @BeforeEach
+        void setUp() {
+            savedSurveyId = surveyService.openSurvey(
+                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertId, BOARDING_DATES));
+        }
+
+        @Nested
+        @DisplayName("유효한 참여 요청 시")
+        class Context_valid_join {
+
+            @Test
+            @DisplayName("참여자가 저장된다")
+            void it_saves_participant() {
+                Long participantId = surveyService.joinSurvey(
+                        savedMember.getId(), SurveyFixture.createJoinSurveyRequest(savedSurveyId, TARGET_DATE));
+                assertThat(participantId).isNotNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("중복 참여 시")
+        class Context_duplicate_join {
+
+            @BeforeEach
+            void setUp() {
+                surveyService.joinSurvey(
+                        savedMember.getId(), SurveyFixture.createJoinSurveyRequest(savedSurveyId, TARGET_DATE));
+            }
+
+            @Test
+            @DisplayName("중복 참여 예외가 발생한다")
+            void it_throws_already_exists() {
+                assertThatThrownBy(() -> surveyService.joinSurvey(
+                                savedMember.getId(), SurveyFixture.createJoinSurveyRequest(savedSurveyId, TARGET_DATE)))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(SurveyErrorCode.SURVEY_JOIN_ALREADY_EXISTS.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelJoin 테스트")
+    class Describe_cancelSurveyJoin {
+
+        private Long savedSurveyId;
+        private static final LocalDate TARGET_DATE = LocalDate.of(2030, 12, 1);
+
+        @BeforeEach
+        void setUp() {
+            savedSurveyId = surveyService.openSurvey(
+                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertId, BOARDING_DATES));
+        }
+
+        @Nested
+        @DisplayName("본인 참여 취소 시")
+        class Context_own_participation {
+
+            @Test
+            @DisplayName("참여자가 삭제된다")
+            void it_deletes_participant() {
+                Long participantId = surveyService.joinSurvey(
+                        savedMember.getId(), SurveyFixture.createJoinSurveyRequest(savedSurveyId, TARGET_DATE));
+                surveyService.cancelJoin(savedMember.getId(), participantId);
+                assertThat(surveyParticipantRepository.findById(participantId)).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("타인의 참여 취소 시")
+        class Context_other_member {
+
+            @Test
+            @DisplayName("접근 거부 예외가 발생한다")
+            void it_throws_access_denied() {
+                Long participantId = surveyService.joinSurvey(
+                        savedMember.getId(), SurveyFixture.createJoinSurveyRequest(savedSurveyId, TARGET_DATE));
+                Member otherMember = memberRepository.save(MemberFixture.createTestMember());
+                assertThatThrownBy(() -> surveyService.cancelJoin(otherMember.getId(), participantId))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(SurveyErrorCode.SURVEY_JOIN_ACCESS_DENIED.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getSurveyDetail 테스트")
+    class Describe_getSurveyDetail {
+
+        private Long savedSurveyId;
+
+        @BeforeEach
+        void setUp() {
+            savedSurveyId = surveyService.openSurvey(
+                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertId, BOARDING_DATES));
+        }
+
+        @Nested
+        @DisplayName("존재하는 수요조사 조회 시")
+        class Context_exists {
+
+            @Test
+            @DisplayName("상세 정보가 반환된다")
+            void it_returns_detail() {
+                SurveyDetailResponse detail = surveyService.findSurveyDetail(savedSurveyId);
+                assertThat(detail).isNotNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 수요조사 조회 시")
+        class Context_not_found {
+
+            @Test
+            @DisplayName("NOT_FOUND 예외가 발생한다")
+            void it_throws_not_found() {
+                assertThatThrownBy(() -> surveyService.findSurveyDetail(999L))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(SurveyErrorCode.SURVEY_NOT_FOUND.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getSurveyList 테스트")
+    class Describe_getSurveyList {
+
+        @BeforeEach
+        void setUp() {
+            surveyService.openSurvey(
+                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertId, BOARDING_DATES));
+        }
+
+        @Test
+        @DisplayName("지역 필터링이 동작한다")
+        void it_filters_by_region() {
+            List<SurveySummaryResponse> seoulResults =
+                    surveyService.findSurveyList(Region.서울, SortType.LATEST, null, null, 10);
+            assertThat(seoulResults).isNotEmpty();
+
+            List<SurveySummaryResponse> busanResults =
+                    surveyService.findSurveyList(Region.부산, SortType.LATEST, null, null, 10);
+            assertThat(busanResults).isEmpty();
+        }
+
+        @Test
+        @DisplayName("최신순 정렬로 목록이 반환된다")
+        void it_sorts_by_latest() {
+            List<SurveySummaryResponse> results = surveyService.findSurveyList(null, SortType.LATEST, null, null, 10);
+            assertThat(results).isNotEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getCreatedSurveyList 테스트")
+    class Describe_getCreatedSurveyList {
+
+        @BeforeEach
+        void setUp() {
+            surveyService.openSurvey(
+                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertId, BOARDING_DATES));
+        }
+
+        @Test
+        @DisplayName("개설자의 수요조사 목록이 반환된다")
+        void it_returns_own_surveys() {
+            var ownSurveys = surveyService.findCreatedSurveyList(savedMember.getId(), null, null, 10);
+            assertThat(ownSurveys).isNotEmpty();
+
+            Member otherMember = memberRepository.save(MemberFixture.createTestMember());
+            var otherSurveys = surveyService.findCreatedSurveyList(otherMember.getId(), null, null, 10);
+            assertThat(otherSurveys).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #5 

### 구현 내용 📢
Recruitment 모듈(Rent / Survey)의 결함 6가지를 수정했습니다.
- RentService.registerRent()에서 차대절 등록 시 RentBoardingSlot 생성 누락
- RentService.updateRent()에서 수정 시 BoardingSlot 동기화 누락
- RentRepositoryImpl.findRentDetail()에서 1:N JOIN + fetchFirst() 로 다중 탑승 날짜 1건만 반환되던 문제 -> 쿼리 2개로 분화
- SurveyService.cancelJoin()에서 취소 시 memberId 권한 검증 누락 + SurveyService.joinSurvey()에서 중복 참여 검증 누락 -> 검증 추가
- 

### 테스트 결과 🧩
- RentIntegrationTest — 17개
- SurveyIntegrationTest — 17개
모두 성공!

### 리뷰 포인트 📌
- findRentDetail() 2-step 쿼리 (RentRepositoryImpl): 기존 Projections.list + fetchFirst() 조합이 1:N에서 첫 row만 반환하는 문제. Tuple fetch 후 boarding dates를 별도 쿼리로 조회해서 생성자 주입하는 방식으로 변경.
- SurveyErrorCode 신규 추가: SURVEY_JOIN_ALREADY_EXISTS, SURVEY_JOIN_ACCESS_DENIED