### PR TITLE
[#7] 차량 대절 동시 신청 동시성 이슈 해결 및 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.3.5'
     id 'io.spring.dependency-management' version '1.1.6'
     id "com.diffplug.spotless" version "8.2.1"
-    id "org.openrewrite.rewrite" version "7.27.0"
+    id "org.openrewrite.rewrite" version "7.29.0"
 }
 
 group = 'com.backend'
@@ -18,6 +18,10 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs << '-parameters'
 }
 
 configurations {

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/application/RentService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/application/RentService.java
@@ -148,15 +148,16 @@ public class RentService {
     // -------------------------
 
     @Transactional
-    public Long applyRent(final RentJoinRequest request, final Long memberId) {
+    public Long joinRent(final RentJoinRequest request, final Long memberId) {
         if (rentParticipantRepository.exists(memberId, request.rentId(), request.boardingDate())) {
             throw new CustomException(RentErrorCode.RENT_JOIN_ALREADY_EXISTS);
         }
 
-        RentBoardingSlot slot = rentBoardingSlotRepository
-                .findByRentIdAndDate(request.rentId(), request.boardingDate())
-                .orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
-        slot.addPassengerCount(request.passengerNum());
+        int updatedPassengerCount = rentBoardingSlotRepository.incrementPassengerCount(
+                request.rentId(), request.boardingDate(), request.passengerNum());
+        if (updatedPassengerCount == 0) {
+            throw new CustomException(RentErrorCode.SLOT_FULL);
+        }
 
         RentParticipant participant = request.toEntity(memberId);
         RentParticipant saved = rentParticipantRepository.save(participant);

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/application/RentService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/application/RentService.java
@@ -153,9 +153,9 @@ public class RentService {
             throw new CustomException(RentErrorCode.RENT_JOIN_ALREADY_EXISTS);
         }
 
-        int updatedPassengerCount = rentBoardingSlotRepository.incrementPassengerCount(
+        int updatedRowCount = rentBoardingSlotRepository.incrementPassengerCount(
                 request.rentId(), request.boardingDate(), request.passengerNum());
-        if (updatedPassengerCount == 0) {
+        if (updatedRowCount == 0) {
             throw new CustomException(RentErrorCode.SLOT_FULL);
         }
 

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/application/dto/RentJoinRequest.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/application/dto/RentJoinRequest.java
@@ -26,7 +26,7 @@ public record RentJoinRequest(
         @NotBlank String depositorName,
         @NotBlank String depositorTime,
 
-        @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
+        @NotBlank @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
         String phone,
 
         @NotNull RefundType refundType,

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/application/dto/RentJoinRequest.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/application/dto/RentJoinRequest.java
@@ -4,8 +4,11 @@ import com.backend.allreva.module.recruitment.rent.domain.participant.RentPartic
 import com.backend.allreva.module.recruitment.rent.domain.value.BoardingType;
 import com.backend.allreva.module.recruitment.rent.domain.value.Depositor;
 import com.backend.allreva.module.recruitment.rent.domain.value.RefundType;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
 import lombok.Builder;
 
@@ -15,14 +18,19 @@ public record RentJoinRequest(
         @NotNull LocalDate boardingDate,
         @NotNull BoardingType boardingType,
 
-        @NotNull @Min(value = 1, message = "탑승 인원 수는 1명 이상이어야 합니다.")
+        @NotNull
+        @Min(value = 1, message = "탑승 인원 수는 1명 이상이어야 합니다.")
+        @Max(value = 45, message = "탑승 인원 수는 45명 이하여야 합니다.")
         int passengerNum,
 
-        @NotNull String depositorName,
-        @NotNull String depositorTime,
-        @NotNull String phone,
+        @NotBlank String depositorName,
+        @NotBlank String depositorTime,
+
+        @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
+        String phone,
+
         @NotNull RefundType refundType,
-        @NotNull String refundAccount) {
+        @NotBlank String refundAccount) {
 
     public RentParticipant toEntity(final Long memberId) {
         return RentParticipant.builder()

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/domain/RentBoardingSlot.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/domain/RentBoardingSlot.java
@@ -1,8 +1,6 @@
 package com.backend.allreva.module.recruitment.rent.domain;
 
-import com.backend.allreva.common.exception.CustomException;
 import com.backend.allreva.common.model.BaseEntity;
-import com.backend.allreva.module.recruitment.rent.exception.RentErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -52,10 +50,4 @@ public class RentBoardingSlot extends BaseEntity {
         this.passengerCount = 0;
     }
 
-    public void addPassengerCount(int count) {
-        if (passengerCount + count > recruitmentCount) {
-            throw new CustomException(RentErrorCode.SLOT_FULL);
-        }
-        this.passengerCount += count;
-    }
 }

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/domain/RentBoardingSlot.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/domain/RentBoardingSlot.java
@@ -49,5 +49,4 @@ public class RentBoardingSlot extends BaseEntity {
         this.recruitmentCount = recruitmentCount;
         this.passengerCount = 0;
     }
-
 }

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/domain/RentBoardingSlotRepository.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/domain/RentBoardingSlotRepository.java
@@ -14,5 +14,7 @@ public interface RentBoardingSlotRepository {
 
     RentBoardingSlot save(RentBoardingSlot slot);
 
+    int incrementPassengerCount(Long rentId, LocalDate boardingDate, int count);
+
     void deleteAllByRentId(Long rentId);
 }

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/infra/RentBoardingSlotRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/infra/RentBoardingSlotRepositoryImpl.java
@@ -36,6 +36,11 @@ public class RentBoardingSlotRepositoryImpl implements RentBoardingSlotRepositor
     }
 
     @Override
+    public int incrementPassengerCount(final Long rentId, final LocalDate boardingDate, final int count) {
+        return rentBoardingSlotJpaRepository.incrementPassengerCount(rentId, boardingDate, count);
+    }
+
+    @Override
     public void deleteAllByRentId(final Long rentId) {
         rentBoardingSlotJpaRepository.deleteAllByRentId(rentId);
     }

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/infra/jpa/RentBoardingSlotJpaRepository.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/infra/jpa/RentBoardingSlotJpaRepository.java
@@ -18,4 +18,15 @@ public interface RentBoardingSlotJpaRepository extends JpaRepository<RentBoardin
     @Modifying
     @Query("UPDATE RentBoardingSlot s SET s.deletedAt = CURRENT_TIMESTAMP WHERE s.rentId = :rentId")
     void deleteAllByRentId(@Param("rentId") Long rentId);
+
+    @Modifying
+    @Query("""
+        UPDATE RentBoardingSlot s
+        SET s.passengerCount = s.passengerCount + :count
+        WHERE s.rentId = :rentId
+          AND s.date = :boardingDate
+          AND s.passengerCount + :count <= s.recruitmentCount
+        """)
+    int incrementPassengerCount(
+            @Param("rentId") Long rentId, @Param("boardingDate") LocalDate boardingDate, @Param("count") int count);
 }

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentController.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentController.java
@@ -113,21 +113,21 @@ public class RentController {
     // Participant Endpoints
     // -------------------------
 
-    @PostMapping("/apply")
-    public Response<Long> applyRent(
+    @PostMapping("/join")
+    public Response<Long> joinRent(
             @RequestBody final RentJoinRequest rentJoinRequest, @AuthMember final Member member) {
-        Long participantId = rentService.applyRent(rentJoinRequest, member.getId());
+        Long participantId = rentService.joinRent(rentJoinRequest, member.getId());
         return Response.onSuccess(participantId);
     }
 
-    @PatchMapping("/apply")
+    @PatchMapping("/join")
     public Response<Void> updateRentJoin(
             @RequestBody final RentJoinUpdateRequest rentJoinUpdateRequest, @AuthMember final Member member) {
         rentService.updateRentJoin(rentJoinUpdateRequest, member.getId());
         return Response.onSuccess();
     }
 
-    @DeleteMapping("/apply")
+    @DeleteMapping("/join")
     public Response<Void> cancelRentJoin(
             @RequestBody final RentJoinIdRequest rentJoinIdRequest, @AuthMember final Member member) {
         rentService.cancelRentJoin(rentJoinIdRequest, member.getId());

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentController.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentController.java
@@ -18,6 +18,7 @@ import com.backend.allreva.module.recruitment.rent.application.dto.RentSummaryRe
 import com.backend.allreva.module.recruitment.rent.application.dto.RentUpdateRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.SortType;
 import com.backend.allreva.module.recruitment.rent.domain.value.Region;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
 import java.util.List;
@@ -43,26 +44,28 @@ public class RentController {
 
     @PostMapping
     public Response<Long> createRent(
-            @RequestBody final RentRegisterRequest rentRegisterRequest, @AuthMember final Member member) {
+            @RequestBody @Valid final RentRegisterRequest rentRegisterRequest, @AuthMember final Member member) {
         Long rentId = rentService.registerRent(rentRegisterRequest, member.getId());
         return Response.onSuccess(rentId);
     }
 
     @PatchMapping
     public Response<Void> updateRent(
-            @RequestBody final RentUpdateRequest rentUpdateRequest, @AuthMember final Member member) {
+            @RequestBody @Valid final RentUpdateRequest rentUpdateRequest, @AuthMember final Member member) {
         rentService.updateRent(rentUpdateRequest, member.getId());
         return Response.onSuccess();
     }
 
     @PatchMapping("/close")
-    public Response<Void> closeRent(@RequestBody final RentIdRequest rentIdRequest, @AuthMember final Member member) {
+    public Response<Void> closeRent(
+            @RequestBody @Valid final RentIdRequest rentIdRequest, @AuthMember final Member member) {
         rentService.closeRent(rentIdRequest, member.getId());
         return Response.onSuccess();
     }
 
     @DeleteMapping
-    public Response<Void> deleteRent(@RequestBody final RentIdRequest rentIdRequest, @AuthMember final Member member) {
+    public Response<Void> deleteRent(
+            @RequestBody @Valid final RentIdRequest rentIdRequest, @AuthMember final Member member) {
         rentService.deleteRent(rentIdRequest, member.getId());
         return Response.onSuccess();
     }
@@ -115,21 +118,21 @@ public class RentController {
 
     @PostMapping("/join")
     public Response<Long> joinRent(
-            @RequestBody final RentJoinRequest rentJoinRequest, @AuthMember final Member member) {
+            @RequestBody @Valid final RentJoinRequest rentJoinRequest, @AuthMember final Member member) {
         Long participantId = rentService.joinRent(rentJoinRequest, member.getId());
         return Response.onSuccess(participantId);
     }
 
     @PatchMapping("/join")
     public Response<Void> updateRentJoin(
-            @RequestBody final RentJoinUpdateRequest rentJoinUpdateRequest, @AuthMember final Member member) {
+            @RequestBody @Valid final RentJoinUpdateRequest rentJoinUpdateRequest, @AuthMember final Member member) {
         rentService.updateRentJoin(rentJoinUpdateRequest, member.getId());
         return Response.onSuccess();
     }
 
     @DeleteMapping("/join")
     public Response<Void> cancelRentJoin(
-            @RequestBody final RentJoinIdRequest rentJoinIdRequest, @AuthMember final Member member) {
+            @RequestBody @Valid final RentJoinIdRequest rentJoinIdRequest, @AuthMember final Member member) {
         rentService.cancelRentJoin(rentJoinIdRequest, member.getId());
         return Response.onSuccess();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        show_sql: true
+        show_sql: false
 
   flyway:
     enabled: true

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/fixture/RentFixture.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/fixture/RentFixture.java
@@ -19,6 +19,11 @@ import lombok.NoArgsConstructor;
 public final class RentFixture {
 
     public static RentRegisterRequest createRentRegisterRequest(Long concertId, List<LocalDate> dates) {
+        return createRentRegisterRequest(concertId, dates, 30);
+    }
+
+    public static RentRegisterRequest createRentRegisterRequest(
+            Long concertId, List<LocalDate> dates, int recruitmentCount) {
         return new RentRegisterRequest(
                 concertId,
                 "테스트 차대절",
@@ -35,7 +40,7 @@ public final class RentFixture {
                 50000,
                 30000,
                 20000,
-                30,
+                recruitmentCount,
                 LocalDate.of(2030, 11, 30),
                 "https://chat.example.com",
                 RefundType.REFUND,

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentConcurrencyTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentConcurrencyTest.java
@@ -1,0 +1,136 @@
+package com.backend.allreva.module.recruitment.rent.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+
+import com.backend.allreva.common.storage.upload.StorageUploadService;
+import com.backend.allreva.module.concert.concert.domain.Concert;
+import com.backend.allreva.module.concert.concert.fixture.ConcertFixture;
+import com.backend.allreva.module.concert.concert.infra.jpa.ConcertJpaRepository;
+import com.backend.allreva.module.member.domain.Member;
+import com.backend.allreva.module.member.domain.MemberRepository;
+import com.backend.allreva.module.member.fixture.MemberFixture;
+import com.backend.allreva.module.recruitment.rent.application.RentService;
+import com.backend.allreva.module.recruitment.rent.fixture.RentFixture;
+import com.backend.allreva.module.recruitment.rent.infra.jpa.RentBoardingSlotJpaRepository;
+import com.backend.allreva.module.recruitment.rent.infra.jpa.RentJpaRepository;
+import com.backend.allreva.module.recruitment.rent.infra.jpa.RentParticipantJpaRepository;
+import com.backend.allreva.support.IntegrationTestSupport;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@DisplayName("Rent 동시성 테스트")
+@SuppressWarnings("NonAsciiCharacters")
+class RentConcurrencyTest extends IntegrationTestSupport {
+
+    private static final int THREAD_COUNT = 5;
+    private static final int RECRUITMENT_COUNT = 3;
+    private static final LocalDate BOARDING_DATE = LocalDate.of(2030, 12, 1);
+
+    @Autowired
+    private RentService rentService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ConcertJpaRepository concertJpaRepository;
+
+    @Autowired
+    private RentJpaRepository rentJpaRepository;
+
+    @Autowired
+    private RentBoardingSlotJpaRepository rentBoardingSlotJpaRepository;
+
+    @Autowired
+    private RentParticipantJpaRepository rentParticipantJpaRepository;
+
+    @MockBean
+    private StorageUploadService storageUploadService;
+
+    private List<Member> members;
+    private Long rentId;
+
+    @BeforeEach
+    void setUp() {
+        doNothing().when(storageUploadService).deleteImage(any());
+
+        members = List.of(
+                memberRepository.save(MemberFixture.createTestMember()),
+                memberRepository.save(MemberFixture.createTestMember()),
+                memberRepository.save(MemberFixture.createTestMember()),
+                memberRepository.save(MemberFixture.createTestMember()),
+                memberRepository.save(MemberFixture.createTestMember()));
+
+        Concert concert = concertJpaRepository.save(ConcertFixture.createTestConcert());
+        rentId = rentService.registerRent(
+                RentFixture.createRentRegisterRequest(concert.getId(), List.of(BOARDING_DATE), RECRUITMENT_COUNT),
+                members.get(0).getId());
+    }
+
+    @AfterEach
+    void tearDown() {
+        rentParticipantJpaRepository.deleteAll();
+        rentBoardingSlotJpaRepository.deleteAll();
+        rentJpaRepository.deleteAll();
+        concertJpaRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("5명이 동시에 신청하면 정원(3명)만 성공해야 한다")
+    void 동시_신청_시_정원_초과_방지() throws InterruptedException {
+        // given
+        ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+        CountDownLatch ready = new CountDownLatch(THREAD_COUNT);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREAD_COUNT);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            final Long memberId = members.get(i).getId();
+            executor.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await(); // 모든 스레드가 동시에 출발
+                    rentService.applyRent(RentFixture.createRentJoinRequest(rentId, BOARDING_DATE, 1), memberId);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await(); // 모든 스레드 준비 대기
+        start.countDown(); // 동시 출발
+        done.await(); // 모든 스레드 완료 대기
+        executor.shutdown();
+
+        // then
+        var slot = rentBoardingSlotJpaRepository
+                .findByRentIdAndDate(rentId, BOARDING_DATE)
+                .orElseThrow();
+
+        System.out.println("failCount: " + failCount.get());
+        System.out.println("successCount: " + successCount.get());
+
+        assertThat(successCount.get()).isEqualTo(RECRUITMENT_COUNT);
+        assertThat(slot.getPassengerCount()).isEqualTo(RECRUITMENT_COUNT);
+    }
+}

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentConcurrencyTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentConcurrencyTest.java
@@ -89,7 +89,7 @@ class RentConcurrencyTest extends IntegrationTestSupport {
     }
 
     @Test
-    @DisplayName("5명이 동시에 신청하면 정원(3명)만 성공해야 한다")
+    @DisplayName("5명이 동시에 신청하면 3명만 성공해야 한다")
     void 동시_신청_시_정원_초과_방지() throws InterruptedException {
         // given
         ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
@@ -106,8 +106,8 @@ class RentConcurrencyTest extends IntegrationTestSupport {
             executor.submit(() -> {
                 ready.countDown();
                 try {
-                    start.await(); // 모든 스레드가 동시에 출발
-                    rentService.applyRent(RentFixture.createRentJoinRequest(rentId, BOARDING_DATE, 1), memberId);
+                    start.await();
+                    rentService.joinRent(RentFixture.createRentJoinRequest(rentId, BOARDING_DATE, 1), memberId);
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failCount.incrementAndGet();
@@ -117,9 +117,9 @@ class RentConcurrencyTest extends IntegrationTestSupport {
             });
         }
 
-        ready.await(); // 모든 스레드 준비 대기
-        start.countDown(); // 동시 출발
-        done.await(); // 모든 스레드 완료 대기
+        ready.await();
+        start.countDown();
+        done.await();
         executor.shutdown();
 
         // then
@@ -127,10 +127,8 @@ class RentConcurrencyTest extends IntegrationTestSupport {
                 .findByRentIdAndDate(rentId, BOARDING_DATE)
                 .orElseThrow();
 
-        System.out.println("failCount: " + failCount.get());
-        System.out.println("successCount: " + successCount.get());
-
         assertThat(successCount.get()).isEqualTo(RECRUITMENT_COUNT);
+        assertThat(failCount.get()).isEqualTo(THREAD_COUNT - RECRUITMENT_COUNT);
         assertThat(slot.getPassengerCount()).isEqualTo(RECRUITMENT_COUNT);
     }
 }

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentConcurrencyTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentConcurrencyTest.java
@@ -1,9 +1,11 @@
 package com.backend.allreva.module.recruitment.rent.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
+import com.backend.allreva.common.exception.CustomException;
 import com.backend.allreva.common.storage.upload.StorageUploadService;
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.fixture.ConcertFixture;
@@ -99,6 +101,7 @@ class RentConcurrencyTest extends IntegrationTestSupport {
 
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger failCount = new AtomicInteger(0);
+        AtomicInteger unexpectedCount = new AtomicInteger(0);
 
         // when
         for (int i = 0; i < THREAD_COUNT; i++) {
@@ -109,8 +112,10 @@ class RentConcurrencyTest extends IntegrationTestSupport {
                     start.await();
                     rentService.joinRent(RentFixture.createRentJoinRequest(rentId, BOARDING_DATE, 1), memberId);
                     successCount.incrementAndGet();
-                } catch (Exception e) {
+                } catch (CustomException e) {
                     failCount.incrementAndGet();
+                } catch (Exception e) {
+                    unexpectedCount.incrementAndGet();
                 } finally {
                     done.countDown();
                 }
@@ -127,8 +132,11 @@ class RentConcurrencyTest extends IntegrationTestSupport {
                 .findByRentIdAndDate(rentId, BOARDING_DATE)
                 .orElseThrow();
 
-        assertThat(successCount.get()).isEqualTo(RECRUITMENT_COUNT);
-        assertThat(failCount.get()).isEqualTo(THREAD_COUNT - RECRUITMENT_COUNT);
-        assertThat(slot.getPassengerCount()).isEqualTo(RECRUITMENT_COUNT);
+        assertThat(unexpectedCount.get()).isZero();
+        assertSoftly(soft -> {
+            soft.assertThat(successCount.get()).isEqualTo(RECRUITMENT_COUNT);
+            soft.assertThat(failCount.get()).isEqualTo(THREAD_COUNT - RECRUITMENT_COUNT);
+            soft.assertThat(slot.getPassengerCount()).isEqualTo(RECRUITMENT_COUNT);
+        });
     }
 }

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentIntegrationTest.java
@@ -302,7 +302,7 @@ class RentIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여자가 저장된다")
             void it_saves_participant() {
-                Long participantId = rentService.applyRent(
+                Long participantId = rentService.joinRent(
                         RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 2), savedMember.getId());
                 assertThat(participantId).isNotNull();
             }
@@ -310,7 +310,7 @@ class RentIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("슬롯의 탑승 인원이 증가한다")
             void it_increases_passenger_count() {
-                rentService.applyRent(
+                rentService.joinRent(
                         RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 3), savedMember.getId());
                 var slot = rentBoardingSlotRepository
                         .findByRentIdAndDate(savedRentId, TARGET_DATE)
@@ -325,14 +325,14 @@ class RentIntegrationTest extends IntegrationTestSupport {
 
             @BeforeEach
             void setUp() {
-                rentService.applyRent(
+                rentService.joinRent(
                         RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 2), savedMember.getId());
             }
 
             @Test
             @DisplayName("중복 신청 예외가 발생한다")
             void it_throws_already_exists() {
-                assertThatThrownBy(() -> rentService.applyRent(
+                assertThatThrownBy(() -> rentService.joinRent(
                                 RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 1), savedMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_JOIN_ALREADY_EXISTS.getMessage());
@@ -346,7 +346,7 @@ class RentIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("슬롯 초과 예외가 발생한다")
             void it_throws_slot_full() {
-                assertThatThrownBy(() -> rentService.applyRent(
+                assertThatThrownBy(() -> rentService.joinRent(
                                 RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 31), savedMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.SLOT_FULL.getMessage());

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -93,7 +93,7 @@ fcm:
 
 logging:
   level:
-    "[com.backend.allreva]": INFO
+    "[com.backend.allreva]": DEBUG
     "[org.hibernate.SQL]": OFF
     "[org.hibernate.type.descriptor.sql.BasicBinder]": OFF
     "[org.springframework.web]": WARN

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -93,7 +93,7 @@ fcm:
 
 logging:
   level:
-    "[com.backend.allreva]": DEBUG
+    "[com.backend.allreva]": INFO
     "[org.hibernate.SQL]": OFF
     "[org.hibernate.type.descriptor.sql.BasicBinder]": OFF
     "[org.springframework.web]": WARN


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #7 

### 구현 내용 📢
차량 대절 동시 신청 시 발생하는 Lost Update 문제를 Atomic UPDATE로 해결

- jpql로 `@Query`, `@Modify`를 이용해서 UPDATE문 구성 -> UPDATE문 원자성 보장 및 동시성 이슈 해결
- `applyRent` → `joinRent` 네이밍 변경
- `RentJoinRequest` validation 추가 (`@Max`, `@NotBlank`, `@Pattern`)
- `-parameters` 컴파일 플래그 추가, `show_sql` 중복 로깅 제거

### 테스트 결과 🧩
- `RentConcurrencyTest`: 5 스레드 동시 신청 → 정원(3명)만 성공, 나머지 2명 `SLOT_FULL` 통과
- k6 부하 테스트: 100 VU 동시 신청 → `passengerCount` 정확히 제한

### 리뷰 포인트 📌

