### PR TITLE
[#44] Concert/place infra 레이어 리팩토링

### DIFF
--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
@@ -8,7 +8,6 @@ import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
 import com.backend.allreva.module.concert.concert.exception.ConcertErrorCode;
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
-import com.backend.allreva.module.concert.place.exception.ConcertHallErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
@@ -40,9 +39,9 @@ public class ConcertService {
         Concert concert = concertRepository
                 .findById(concertCode)
                 .orElseThrow(() -> new CustomException(ConcertErrorCode.CONCERT_NOT_FOUND));
-        ConcertHall hall = concertHallRepository
-                .findById(concert.getHallCode())
-                .orElseThrow(() -> new CustomException(ConcertHallErrorCode.CONCERT_HALL_NOT_FOUND));
+        ConcertHall hall = concert != null
+                ? concertHallRepository.findById(concert.getHallCode()).orElse(null)
+                : null;
         return ConcertDetailResponse.from(concert, hall);
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
@@ -28,9 +28,11 @@ public class ConcertService {
             key = "#hallCode + '_' + #lastConcertCode + '_' + #pageSize",
             unless = "#result == null",
             cacheManager = "relatedConcertCacheManager")
-    public List<RelatedConcertResponse> findRelatedConcertsByHall(
+    public List<RelatedConcertResponse> getRelatedConcertsByHallCode(
             final String hallCode, final String lastConcertCode, final int pageSize) {
-        return concertRepository.findRelatedConcertsByHall(hallCode, lastConcertCode, pageSize);
+        return concertRepository.findAllByHallCode(hallCode, lastConcertCode, pageSize).stream()
+                .map(RelatedConcertResponse::from)
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -39,7 +41,7 @@ public class ConcertService {
                 .findById(concertCode)
                 .orElseThrow(() -> new CustomException(ConcertErrorCode.CONCERT_NOT_FOUND));
         ConcertHall hall = concertHallRepository
-                .findByHallCode(concert.getHallCode())
+                .findById(concert.getHallCode())
                 .orElseThrow(() -> new CustomException(ConcertHallErrorCode.CONCERT_HALL_NOT_FOUND));
         return ConcertDetailResponse.from(concert, hall);
     }

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
@@ -2,6 +2,8 @@ package com.backend.allreva.module.concert.concert.application;
 
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
+import com.backend.allreva.module.concert.place.domain.ConcertHall;
+import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,9 +13,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class ConcertService {
 
     private final ConcertRepository concertRepository;
+    private final ConcertHallRepository concertHallRepository;
 
     @Transactional(readOnly = true)
     public ConcertDetailResponse findDetailById(final String concertCode) {
-        return concertRepository.findDetailById(concertCode);
+        return concertRepository
+                .findById(concertCode)
+                .map(concert -> {
+                    ConcertHall hall = concertHallRepository
+                            .findByHallCode(concert.getHallCode())
+                            .orElse(null);
+                    return ConcertDetailResponse.from(concert, hall);
+                })
+                .orElse(ConcertDetailResponse.EMPTY);
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
@@ -2,13 +2,16 @@ package com.backend.allreva.module.concert.concert.application;
 
 import com.backend.allreva.common.exception.CustomException;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
+import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
 import com.backend.allreva.module.concert.concert.exception.ConcertErrorCode;
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
 import com.backend.allreva.module.concert.place.exception.ConcertHallErrorCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +21,17 @@ public class ConcertService {
 
     private final ConcertRepository concertRepository;
     private final ConcertHallRepository concertHallRepository;
+
+    @Transactional(readOnly = true)
+    @Cacheable(
+            cacheNames = "relatedConcert",
+            key = "#hallCode + '_' + #lastConcertCode + '_' + #pageSize",
+            unless = "#result == null",
+            cacheManager = "relatedConcertCacheManager")
+    public List<RelatedConcertResponse> findRelatedConcertsByHall(
+            final String hallCode, final String lastConcertCode, final int pageSize) {
+        return concertRepository.findRelatedConcertsByHall(hallCode, lastConcertCode, pageSize);
+    }
 
     @Transactional(readOnly = true)
     public ConcertDetailResponse findDetailById(final String concertCode) {

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
@@ -1,9 +1,13 @@
 package com.backend.allreva.module.concert.concert.application;
 
+import com.backend.allreva.common.exception.CustomException;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
+import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
+import com.backend.allreva.module.concert.concert.exception.ConcertErrorCode;
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
+import com.backend.allreva.module.concert.place.exception.ConcertHallErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,14 +21,12 @@ public class ConcertService {
 
     @Transactional(readOnly = true)
     public ConcertDetailResponse findDetailById(final String concertCode) {
-        return concertRepository
+        Concert concert = concertRepository
                 .findById(concertCode)
-                .map(concert -> {
-                    ConcertHall hall = concertHallRepository
-                            .findByHallCode(concert.getHallCode())
-                            .orElse(null);
-                    return ConcertDetailResponse.from(concert, hall);
-                })
-                .orElse(ConcertDetailResponse.EMPTY);
+                .orElseThrow(() -> new CustomException(ConcertErrorCode.CONCERT_NOT_FOUND));
+        ConcertHall hall = concertHallRepository
+                .findByHallCode(concert.getHallCode())
+                .orElseThrow(() -> new CustomException(ConcertHallErrorCode.CONCERT_HALL_NOT_FOUND));
+        return ConcertDetailResponse.from(concert, hall);
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
@@ -28,7 +28,7 @@ public class ConcertService {
             key = "#hallCode + '_' + #lastConcertCode + '_' + #pageSize",
             unless = "#result == null",
             cacheManager = "relatedConcertCacheManager")
-    public List<RelatedConcertResponse> getRelatedConcertsByHallCode(
+    public List<RelatedConcertResponse> getRelatedConcerts(
             final String hallCode, final String lastConcertCode, final int pageSize) {
         return concertRepository.findAllByHallCode(hallCode, lastConcertCode, pageSize).stream()
                 .map(RelatedConcertResponse::from)

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/dto/ConcertDateInfoResponse.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/dto/ConcertDateInfoResponse.java
@@ -1,9 +1,0 @@
-package com.backend.allreva.module.concert.concert.application.dto;
-
-import java.time.LocalDate;
-
-public interface ConcertDateInfoResponse {
-    LocalDate getStartDate();
-
-    LocalDate getEndDate();
-}

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/dto/RelatedConcertResponse.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/dto/RelatedConcertResponse.java
@@ -12,6 +12,6 @@ public record RelatedConcertResponse(
                 concert.getConcertInfo().getTitle(),
                 concert.getConcertInfo().getDateInfo().getStartDate(),
                 concert.getConcertInfo().getDateInfo().getEndDate(),
-                concert.getPoster().getUrl());
+                concert.getPoster() != null ? concert.getPoster().getUrl() : null);
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/dto/RelatedConcertResponse.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/dto/RelatedConcertResponse.java
@@ -1,4 +1,4 @@
-package com.backend.allreva.module.concert.place.application.dto;
+package com.backend.allreva.module.concert.concert.application.dto;
 
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import java.time.LocalDate;

--- a/src/main/java/com/backend/allreva/module/concert/concert/domain/Concert.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/domain/Concert.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -57,6 +58,12 @@ public class Concert extends BaseEntity {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "cast_names", columnDefinition = "jsonb", nullable = false)
     private List<String> castNames = new ArrayList<>();
+
+    public boolean isValidBoardingDate(final LocalDate date) {
+        LocalDate startDate = concertInfo.getDateInfo().getStartDate();
+        LocalDate endDate = concertInfo.getDateInfo().getEndDate();
+        return !date.isBefore(startDate) && !date.isAfter(endDate);
+    }
 
     public void updateFrom(final Concert fetched) {
         this.hallCode = fetched.hallCode;

--- a/src/main/java/com/backend/allreva/module/concert/concert/domain/ConcertRepository.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/domain/ConcertRepository.java
@@ -1,6 +1,5 @@
 package com.backend.allreva.module.concert.concert.domain;
 
-import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,7 +9,7 @@ public interface ConcertRepository {
 
     List<Concert> findAll();
 
-    List<RelatedConcertResponse> findRelatedConcertsByHall(String hallCode, String lastConcertCode, int pageSize);
+    List<Concert> findAllByHallCode(String hallCode, String lastConcertCode, int pageSize);
 
     Concert save(Concert concert);
 

--- a/src/main/java/com/backend/allreva/module/concert/concert/domain/ConcertRepository.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/domain/ConcertRepository.java
@@ -1,6 +1,5 @@
 package com.backend.allreva.module.concert.concert.domain;
 
-import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.place.application.dto.RelatedConcertResponse;
 import java.util.List;
 import java.util.Optional;
@@ -10,8 +9,6 @@ public interface ConcertRepository {
     Optional<Concert> findById(String concertCode);
 
     List<Concert> findAll();
-
-    ConcertDetailResponse findDetailById(String concertCode);
 
     List<RelatedConcertResponse> findRelatedConcertsByHall(String hallCode, String lastConcertCode, int pageSize);
 

--- a/src/main/java/com/backend/allreva/module/concert/concert/domain/ConcertRepository.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/domain/ConcertRepository.java
@@ -1,29 +1,21 @@
 package com.backend.allreva.module.concert.concert.domain;
 
-import com.backend.allreva.module.concert.concert.application.dto.ConcertDateInfoResponse;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.place.application.dto.RelatedConcertResponse;
-import com.backend.allreva.module.search.application.dto.ConcertThumbnail;
 import java.util.List;
 import java.util.Optional;
 
 public interface ConcertRepository {
 
-    Concert save(Concert concert);
-
     Optional<Concert> findById(String concertCode);
 
     List<Concert> findAll();
 
-    Optional<ConcertDateInfoResponse> findStartDateAndEndDateById(String concertCode);
-
     ConcertDetailResponse findDetailById(String concertCode);
-
-    List<ConcertThumbnail> getConcertMainThumbnails();
 
     List<RelatedConcertResponse> findRelatedConcertsByHall(String hallCode, String lastConcertCode, int pageSize);
 
-    void deleteAll();
+    Concert save(Concert concert);
 
-    void deleteAllInBatch();
+    void deleteAll();
 }

--- a/src/main/java/com/backend/allreva/module/concert/concert/domain/ConcertRepository.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/domain/ConcertRepository.java
@@ -1,6 +1,6 @@
 package com.backend.allreva.module.concert.concert.domain;
 
-import com.backend.allreva.module.concert.place.application.dto.RelatedConcertResponse;
+import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/com/backend/allreva/module/concert/concert/infra/ConcertRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/infra/ConcertRepositoryImpl.java
@@ -2,10 +2,10 @@ package com.backend.allreva.module.concert.concert.infra;
 
 import static com.backend.allreva.module.concert.concert.domain.QConcert.concert;
 
+import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
 import com.backend.allreva.module.concert.concert.infra.jpa.ConcertJpaRepository;
-import com.backend.allreva.module.concert.place.application.dto.RelatedConcertResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -35,13 +35,17 @@ public class ConcertRepositoryImpl implements ConcertRepository {
             final String hallCode, final String lastConcertCode, final int pageSize) {
         return queryFactory
                 .selectFrom(concert)
-                .where(eqHallCode(hallCode), ltConcertCode(lastConcertCode))
+                .where(concert.hallCode.eq(hallCode), ltConcertCode(lastConcertCode))
                 .orderBy(concert.concertCode.desc())
                 .limit(pageSize)
                 .fetch()
                 .stream()
                 .map(RelatedConcertResponse::from)
                 .toList();
+    }
+
+    private BooleanExpression ltConcertCode(final String lastConcertCode) {
+        return lastConcertCode != null ? concert.concertCode.lt(lastConcertCode) : null;
     }
 
     @Override
@@ -52,13 +56,5 @@ public class ConcertRepositoryImpl implements ConcertRepository {
     @Override
     public void deleteAll() {
         jpa.deleteAll();
-    }
-
-    private BooleanExpression eqHallCode(final String hallCode) {
-        return hallCode != null ? concert.hallCode.eq(hallCode) : null;
-    }
-
-    private BooleanExpression ltConcertCode(final String lastConcertCode) {
-        return lastConcertCode != null ? concert.concertCode.lt(lastConcertCode) : null;
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/concert/infra/ConcertRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/infra/ConcertRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.backend.allreva.module.concert.concert.infra;
 
 import static com.backend.allreva.module.concert.concert.domain.QConcert.concert;
 
-import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
 import com.backend.allreva.module.concert.concert.infra.jpa.ConcertJpaRepository;
@@ -31,17 +30,13 @@ public class ConcertRepositoryImpl implements ConcertRepository {
     }
 
     @Override
-    public List<RelatedConcertResponse> findRelatedConcertsByHall(
-            final String hallCode, final String lastConcertCode, final int pageSize) {
+    public List<Concert> findAllByHallCode(final String hallCode, final String lastConcertCode, final int pageSize) {
         return queryFactory
                 .selectFrom(concert)
                 .where(concert.hallCode.eq(hallCode), ltConcertCode(lastConcertCode))
                 .orderBy(concert.concertCode.desc())
                 .limit(pageSize)
-                .fetch()
-                .stream()
-                .map(RelatedConcertResponse::from)
-                .toList();
+                .fetch();
     }
 
     private BooleanExpression ltConcertCode(final String lastConcertCode) {

--- a/src/main/java/com/backend/allreva/module/concert/concert/infra/ConcertRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/infra/ConcertRepositoryImpl.java
@@ -1,9 +1,7 @@
 package com.backend.allreva.module.concert.concert.infra;
 
 import static com.backend.allreva.module.concert.concert.domain.QConcert.concert;
-import static com.backend.allreva.module.concert.place.domain.QConcertHall.concertHall;
 
-import com.backend.allreva.module.concert.concert.application.dto.ConcertDateInfoResponse;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
@@ -11,11 +9,8 @@ import com.backend.allreva.module.concert.concert.infra.jpa.ConcertJpaRepository
 import com.backend.allreva.module.concert.place.application.dto.RelatedConcertResponse;
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.infra.jpa.ConcertHallJpaRepository;
-import com.backend.allreva.module.search.application.dto.ConcertThumbnail;
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -45,11 +40,6 @@ public class ConcertRepositoryImpl implements ConcertRepository {
     }
 
     @Override
-    public Optional<ConcertDateInfoResponse> findStartDateAndEndDateById(final String concertCode) {
-        return jpa.findStartDateAndEndDateByConcertCode(concertCode);
-    }
-
-    @Override
     public ConcertDetailResponse findDetailById(final String concertCode) {
         return jpa.findById(concertCode)
                 .map(concertEntity -> {
@@ -61,51 +51,22 @@ public class ConcertRepositoryImpl implements ConcertRepository {
     }
 
     @Override
-    public List<ConcertThumbnail> getConcertMainThumbnails() {
-        return queryFactory
-                .select(Projections.constructor(
-                        ConcertThumbnail.class,
-                        concert.poster.url,
-                        concert.concertInfo.title,
-                        concertHall.name,
-                        concert.concertInfo.dateInfo.startDate,
-                        concert.concertInfo.dateInfo.endDate,
-                        concert.concertCode))
-                .from(concert)
-                .leftJoin(concertHall)
-                .on(concert.hallCode.eq(concertHall.hallCode))
-                .where(concert.concertInfo.dateInfo.endDate.goe(LocalDate.now()))
-                .orderBy(concert.concertInfo.dateInfo.startDate.asc())
-                .limit(5)
-                .fetch();
-    }
-
-    @Override
     public List<RelatedConcertResponse> findRelatedConcertsByHall(
             final String hallCode, final String lastConcertCode, final int pageSize) {
         return queryFactory
-                .select(Projections.constructor(
-                        RelatedConcertResponse.class,
-                        concert.concertCode,
-                        concert.concertInfo.title,
-                        concert.concertInfo.dateInfo.startDate,
-                        concert.concertInfo.dateInfo.endDate,
-                        concert.poster.url))
-                .from(concert)
+                .selectFrom(concert)
                 .where(eqHallCode(hallCode), ltConcertCode(lastConcertCode))
                 .orderBy(concert.concertCode.desc())
                 .limit(pageSize)
-                .fetch();
+                .fetch()
+                .stream()
+                .map(RelatedConcertResponse::from)
+                .toList();
     }
 
     @Override
     public void deleteAll() {
         jpa.deleteAll();
-    }
-
-    @Override
-    public void deleteAllInBatch() {
-        jpa.deleteAllInBatch();
     }
 
     private BooleanExpression eqHallCode(final String hallCode) {

--- a/src/main/java/com/backend/allreva/module/concert/concert/infra/ConcertRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/infra/ConcertRepositoryImpl.java
@@ -2,13 +2,10 @@ package com.backend.allreva.module.concert.concert.infra;
 
 import static com.backend.allreva.module.concert.concert.domain.QConcert.concert;
 
-import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
 import com.backend.allreva.module.concert.concert.infra.jpa.ConcertJpaRepository;
 import com.backend.allreva.module.concert.place.application.dto.RelatedConcertResponse;
-import com.backend.allreva.module.concert.place.domain.ConcertHall;
-import com.backend.allreva.module.concert.place.infra.jpa.ConcertHallJpaRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -21,13 +18,7 @@ import org.springframework.stereotype.Repository;
 public class ConcertRepositoryImpl implements ConcertRepository {
 
     private final ConcertJpaRepository jpa;
-    private final ConcertHallJpaRepository concertHallJpa;
     private final JPAQueryFactory queryFactory;
-
-    @Override
-    public Concert save(final Concert concertEntity) {
-        return jpa.save(concertEntity);
-    }
 
     @Override
     public Optional<Concert> findById(final String concertCode) {
@@ -37,17 +28,6 @@ public class ConcertRepositoryImpl implements ConcertRepository {
     @Override
     public List<Concert> findAll() {
         return jpa.findAll();
-    }
-
-    @Override
-    public ConcertDetailResponse findDetailById(final String concertCode) {
-        return jpa.findById(concertCode)
-                .map(concertEntity -> {
-                    ConcertHall hall =
-                            concertHallJpa.findById(concertEntity.getHallCode()).orElse(null);
-                    return ConcertDetailResponse.from(concertEntity, hall);
-                })
-                .orElse(ConcertDetailResponse.EMPTY);
     }
 
     @Override
@@ -62,6 +42,11 @@ public class ConcertRepositoryImpl implements ConcertRepository {
                 .stream()
                 .map(RelatedConcertResponse::from)
                 .toList();
+    }
+
+    @Override
+    public Concert save(final Concert concertEntity) {
+        return jpa.save(concertEntity);
     }
 
     @Override

--- a/src/main/java/com/backend/allreva/module/concert/concert/infra/jpa/ConcertJpaRepository.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/infra/jpa/ConcertJpaRepository.java
@@ -1,16 +1,6 @@
 package com.backend.allreva.module.concert.concert.infra.jpa;
 
-import com.backend.allreva.module.concert.concert.application.dto.ConcertDateInfoResponse;
 import com.backend.allreva.module.concert.concert.domain.Concert;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface ConcertJpaRepository extends JpaRepository<Concert, String> {
-
-    @Query("SELECT c.concertInfo.dateInfo.startDate AS startDate, "
-            + "c.concertInfo.dateInfo.endDate AS endDate "
-            + "FROM Concert c WHERE c.concertCode = :concertCode")
-    Optional<ConcertDateInfoResponse> findStartDateAndEndDateByConcertCode(@Param("concertCode") String concertCode);
-}
+public interface ConcertJpaRepository extends JpaRepository<Concert, String> {}

--- a/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertController.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertController.java
@@ -3,15 +3,20 @@ package com.backend.allreva.module.concert.concert.presentation;
 import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.concert.concert.application.ConcertService;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
+import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -28,5 +33,13 @@ public class ConcertController implements ConcertControllerSwagger {
     public Response<ConcertDetailResponse> findConcertDetail(@PathVariable("concertCode") final String concertCode) {
         ConcertDetailResponse detail = concertService.findDetailById(concertCode);
         return Response.onSuccess(detail);
+    }
+
+    @GetMapping("/by-hall")
+    public Response<List<RelatedConcertResponse>> findRelatedConcertsByHall(
+            @NotBlank @RequestParam final String hallCode,
+            @RequestParam(required = false) final String lastConcertCode,
+            @Positive @RequestParam(defaultValue = "3") final int pageSize) {
+        return Response.onSuccess(concertService.findRelatedConcertsByHall(hallCode, lastConcertCode, pageSize));
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertController.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertController.java
@@ -4,10 +4,6 @@ import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.concert.concert.application.ConcertService;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
@@ -27,19 +23,19 @@ public class ConcertController implements ConcertControllerSwagger {
 
     private final ConcertService concertService;
 
-    @Operation(summary = "공연 상세 조회", description = "공연 상세 조회 API")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json"))})
+    @Override
     @GetMapping("/{concertCode}")
-    public Response<ConcertDetailResponse> getConcertDetail(@PathVariable("concertCode") final String concertCode) {
-        ConcertDetailResponse detail = concertService.findDetailById(concertCode);
-        return Response.onSuccess(detail);
+    public Response<ConcertDetailResponse> getConcertDetail(
+            @NotBlank @PathVariable("concertCode") final String concertCode) {
+        return Response.onSuccess(concertService.findDetailById(concertCode));
     }
 
-    @GetMapping("/by-hall")
-    public Response<List<RelatedConcertResponse>> getRelatedConcertsByHallCode(
+    @Override
+    @GetMapping
+    public Response<List<RelatedConcertResponse>> getRelatedConcerts(
             @NotBlank @RequestParam final String hallCode,
             @RequestParam(required = false) final String lastConcertCode,
             @Positive @RequestParam(defaultValue = "3") final int pageSize) {
-        return Response.onSuccess(concertService.getRelatedConcertsByHallCode(hallCode, lastConcertCode, pageSize));
+        return Response.onSuccess(concertService.getRelatedConcerts(hallCode, lastConcertCode, pageSize));
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertController.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertController.java
@@ -30,16 +30,16 @@ public class ConcertController implements ConcertControllerSwagger {
     @Operation(summary = "공연 상세 조회", description = "공연 상세 조회 API")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json"))})
     @GetMapping("/{concertCode}")
-    public Response<ConcertDetailResponse> findConcertDetail(@PathVariable("concertCode") final String concertCode) {
+    public Response<ConcertDetailResponse> getConcertDetail(@PathVariable("concertCode") final String concertCode) {
         ConcertDetailResponse detail = concertService.findDetailById(concertCode);
         return Response.onSuccess(detail);
     }
 
     @GetMapping("/by-hall")
-    public Response<List<RelatedConcertResponse>> findRelatedConcertsByHall(
+    public Response<List<RelatedConcertResponse>> getRelatedConcertsByHallCode(
             @NotBlank @RequestParam final String hallCode,
             @RequestParam(required = false) final String lastConcertCode,
             @Positive @RequestParam(defaultValue = "3") final int pageSize) {
-        return Response.onSuccess(concertService.findRelatedConcertsByHall(hallCode, lastConcertCode, pageSize));
+        return Response.onSuccess(concertService.getRelatedConcertsByHallCode(hallCode, lastConcertCode, pageSize));
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertControllerSwagger.java
@@ -4,22 +4,19 @@ import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "공연 API", description = "공연 API")
 public interface ConcertControllerSwagger {
 
     @Operation(summary = "공연 상세 조회", description = "공연 상세 조회 API")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json"))})
-    Response<ConcertDetailResponse> getConcertDetail(String concertCode);
+    Response<ConcertDetailResponse> getConcertDetail(@PathVariable("concertCode") String concertCode);
 
     @Operation(summary = "공연장 관련 공연 목록 조회", description = "공연장 코드 기준 관련 공연 무한 스크롤")
-    Response<List<RelatedConcertResponse>> getRelatedConcertsByHallCode(
+    Response<List<RelatedConcertResponse>> getRelatedConcerts(
             @RequestParam String hallCode,
             @RequestParam(required = false) String lastConcertCode,
             @RequestParam(defaultValue = "3") int pageSize);

--- a/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertControllerSwagger.java
@@ -4,20 +4,22 @@ import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "공연 API", description = "공연 API")
 public interface ConcertControllerSwagger {
 
     @Operation(summary = "공연 상세 조회", description = "공연 상세 조회 API")
-    Response<ConcertDetailResponse> findConcertDetail(String concertCode);
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json"))})
+    Response<ConcertDetailResponse> getConcertDetail(String concertCode);
 
     @Operation(summary = "공연장 관련 공연 목록 조회", description = "공연장 코드 기준 관련 공연 무한 스크롤")
-    @GetMapping("/by-hall")
-    Response<List<RelatedConcertResponse>> findRelatedConcertsByHall(
+    Response<List<RelatedConcertResponse>> getRelatedConcertsByHallCode(
             @RequestParam String hallCode,
             @RequestParam(required = false) String lastConcertCode,
             @RequestParam(defaultValue = "3") int pageSize);

--- a/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertControllerSwagger.java
@@ -2,12 +2,23 @@ package com.backend.allreva.module.concert.concert.presentation;
 
 import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
+import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "공연 API", description = "공연 API")
 public interface ConcertControllerSwagger {
 
     @Operation(summary = "공연 상세 조회", description = "공연 상세 조회 API")
     Response<ConcertDetailResponse> findConcertDetail(String concertCode);
+
+    @Operation(summary = "공연장 관련 공연 목록 조회", description = "공연장 코드 기준 관련 공연 무한 스크롤")
+    @GetMapping("/by-hall")
+    Response<List<RelatedConcertResponse>> findRelatedConcertsByHall(
+            @RequestParam String hallCode,
+            @RequestParam(required = false) String lastConcertCode,
+            @RequestParam(defaultValue = "3") int pageSize);
 }

--- a/src/main/java/com/backend/allreva/module/concert/place/application/ConcertHallService.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/application/ConcertHallService.java
@@ -13,12 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class HallService {
+public class ConcertHallService {
 
     private final ConcertHallRepository concertHallRepository;
 
     @Transactional(readOnly = true)
-    public ConcertHallDetailResponse findDetailByHallCode(final String hallCode) {
+    public ConcertHallDetailResponse getConcertHallDetail(final String hallCode) {
         ConcertHall hall = concertHallRepository
                 .findById(hallCode)
                 .orElseThrow(() -> new CustomException(ConcertHallErrorCode.CONCERT_HALL_NOT_FOUND));

--- a/src/main/java/com/backend/allreva/module/concert/place/application/HallService.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/application/HallService.java
@@ -1,7 +1,10 @@
 package com.backend.allreva.module.concert.place.application;
 
+import com.backend.allreva.common.exception.CustomException;
 import com.backend.allreva.module.concert.place.application.dto.ConcertHallDetailResponse;
+import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
+import com.backend.allreva.module.concert.place.exception.ConcertHallErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,6 +19,9 @@ public class HallService {
 
     @Transactional(readOnly = true)
     public ConcertHallDetailResponse findDetailByHallCode(final String hallCode) {
-        return concertHallRepository.findDetailByHallCode(hallCode);
+        ConcertHall hall = concertHallRepository
+                .findById(hallCode)
+                .orElseThrow(() -> new CustomException(ConcertHallErrorCode.CONCERT_HALL_NOT_FOUND));
+        return ConcertHallDetailResponse.from(hall);
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/place/application/HallService.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/application/HallService.java
@@ -1,15 +1,9 @@
 package com.backend.allreva.module.concert.place.application;
 
-import com.backend.allreva.common.exception.CustomException;
-import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
 import com.backend.allreva.module.concert.place.application.dto.ConcertHallDetailResponse;
-import com.backend.allreva.module.concert.place.application.dto.RelatedConcertResponse;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
-import com.backend.allreva.module.concert.place.exception.ConcertHallErrorCode;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,25 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class HallService {
 
     private final ConcertHallRepository concertHallRepository;
-    private final ConcertRepository concertRepository;
 
     @Transactional(readOnly = true)
     public ConcertHallDetailResponse findDetailByHallCode(final String hallCode) {
         return concertHallRepository.findDetailByHallCode(hallCode);
-    }
-
-    @Transactional(readOnly = true)
-    @Cacheable(
-            cacheNames = "relatedConcert",
-            key = "#hallCode + '_' + #lastConcertCode + '_' + #pageSize",
-            unless = "#result == null",
-            cacheManager = "relatedConcertCacheManager")
-    public List<RelatedConcertResponse> getRelatedConcert(
-            final String hallCode, final String lastConcertCode, final int pageSize) {
-        try {
-            return concertRepository.findRelatedConcertsByHall(hallCode, lastConcertCode, pageSize);
-        } catch (Exception e) {
-            throw new CustomException(ConcertHallErrorCode.RELATED_CONCERT_EXCEPTION);
-        }
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/place/application/dto/ConcertHallDetailResponse.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/application/dto/ConcertHallDetailResponse.java
@@ -1,7 +1,14 @@
 package com.backend.allreva.module.concert.place.application.dto;
 
+import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.value.ConvenienceInfo;
 import com.backend.allreva.module.concert.place.domain.value.Location;
 
 public record ConcertHallDetailResponse(
-        String name, Integer seatScale, ConvenienceInfo convenienceInfo, Location location) {}
+        String name, Integer seatScale, ConvenienceInfo convenienceInfo, Location location) {
+
+    public static ConcertHallDetailResponse from(final ConcertHall hall) {
+        return new ConcertHallDetailResponse(
+                hall.getName(), hall.getSeatScale(), hall.getConvenienceInfo(), hall.getLocation());
+    }
+}

--- a/src/main/java/com/backend/allreva/module/concert/place/application/dto/RelatedConcertResponse.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/application/dto/RelatedConcertResponse.java
@@ -1,6 +1,17 @@
 package com.backend.allreva.module.concert.place.application.dto;
 
+import com.backend.allreva.module.concert.concert.domain.Concert;
 import java.time.LocalDate;
 
 public record RelatedConcertResponse(
-        String concertCode, String title, LocalDate startDate, LocalDate endDate, String posterUrl) {}
+        String concertCode, String title, LocalDate startDate, LocalDate endDate, String posterUrl) {
+
+    public static RelatedConcertResponse from(final Concert concert) {
+        return new RelatedConcertResponse(
+                concert.getConcertCode(),
+                concert.getConcertInfo().getTitle(),
+                concert.getConcertInfo().getDateInfo().getStartDate(),
+                concert.getConcertInfo().getDateInfo().getEndDate(),
+                concert.getPoster().getUrl());
+    }
+}

--- a/src/main/java/com/backend/allreva/module/concert/place/domain/ConcertHallRepository.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/domain/ConcertHallRepository.java
@@ -1,6 +1,5 @@
 package com.backend.allreva.module.concert.place.domain;
 
-import com.backend.allreva.module.concert.place.application.dto.ConcertHallDetailResponse;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -9,9 +8,7 @@ public interface ConcertHallRepository {
 
     ConcertHall save(ConcertHall concertHall);
 
-    ConcertHallDetailResponse findDetailByHallCode(String hallCode);
-
-    Optional<ConcertHall> findByHallCode(String hallCode);
+    Optional<ConcertHall> findById(String hallCode);
 
     List<String> findAllHallCodes();
 

--- a/src/main/java/com/backend/allreva/module/concert/place/domain/ConcertHallRepository.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/domain/ConcertHallRepository.java
@@ -6,8 +6,6 @@ import java.util.Set;
 
 public interface ConcertHallRepository {
 
-    ConcertHall save(ConcertHall concertHall);
-
     Optional<ConcertHall> findById(String hallCode);
 
     List<String> findAllHallCodes();
@@ -15,6 +13,8 @@ public interface ConcertHallRepository {
     Set<String> findAllFacilityCodes();
 
     Set<String> findHallCodesByFacilityCode(String facilityCode);
+
+    ConcertHall save(ConcertHall concertHall);
 
     void deleteAll();
 }

--- a/src/main/java/com/backend/allreva/module/concert/place/domain/ConcertHallRepository.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/domain/ConcertHallRepository.java
@@ -9,8 +9,6 @@ public interface ConcertHallRepository {
 
     ConcertHall save(ConcertHall concertHall);
 
-    Optional<ConcertHall> findByHallCodeWithLock(String hallCode);
-
     ConcertHallDetailResponse findDetailByHallCode(String hallCode);
 
     Optional<ConcertHall> findByHallCode(String hallCode);

--- a/src/main/java/com/backend/allreva/module/concert/place/exception/ConcertHallErrorCode.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/exception/ConcertHallErrorCode.java
@@ -9,8 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ConcertHallErrorCode implements ErrorCode {
     CONCERT_HALL_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "CONCERT_HALL_NOT_FOUND", "존재하지 않는 공연장입니다"),
-    CONCERT_HALL_SEARCH_NOTFOUND(HttpStatus.NOT_FOUND.value(), "CONCERT_HALL_SEARCH_NOT_FOUND", "존재하는 공연장이 없습니다"),
-    RELATED_CONCERT_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR.value(), "RELATED_CONCERT_EXCEPTION", "연관 콘서트 에러");
+    CONCERT_HALL_SEARCH_NOTFOUND(HttpStatus.NOT_FOUND.value(), "CONCERT_HALL_SEARCH_NOT_FOUND", "존재하는 공연장이 없습니다");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/backend/allreva/module/concert/place/exception/ConcertHallErrorCode.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/exception/ConcertHallErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ConcertHallErrorCode implements ErrorCode {
+    CONCERT_HALL_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "CONCERT_HALL_NOT_FOUND", "존재하지 않는 공연장입니다"),
     CONCERT_HALL_SEARCH_NOTFOUND(HttpStatus.NOT_FOUND.value(), "CONCERT_HALL_SEARCH_NOT_FOUND", "존재하는 공연장이 없습니다"),
     RELATED_CONCERT_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR.value(), "RELATED_CONCERT_EXCEPTION", "연관 콘서트 에러");
 

--- a/src/main/java/com/backend/allreva/module/concert/place/infra/ConcertHallRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/infra/ConcertHallRepositoryImpl.java
@@ -17,18 +17,8 @@ public class ConcertHallRepositoryImpl implements ConcertHallRepository {
     private final ConcertHallJpaRepository jpa;
 
     @Override
-    public ConcertHall save(final ConcertHall concertHallEntity) {
-        return jpa.save(concertHallEntity);
-    }
-
-    @Override
     public Optional<ConcertHall> findById(final String hallCode) {
         return jpa.findById(hallCode);
-    }
-
-    @Override
-    public void deleteAll() {
-        jpa.deleteAll();
     }
 
     @Override
@@ -44,5 +34,15 @@ public class ConcertHallRepositoryImpl implements ConcertHallRepository {
     @Override
     public Set<String> findHallCodesByFacilityCode(final String facilityCode) {
         return new HashSet<>(jpa.findHallCodesByFacilityCode(facilityCode));
+    }
+
+    @Override
+    public ConcertHall save(final ConcertHall concertHallEntity) {
+        return jpa.save(concertHallEntity);
+    }
+
+    @Override
+    public void deleteAll() {
+        jpa.deleteAll();
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/place/infra/ConcertHallRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/infra/ConcertHallRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.backend.allreva.module.concert.place.infra;
 
-import com.backend.allreva.module.concert.place.application.dto.ConcertHallDetailResponse;
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
 import com.backend.allreva.module.concert.place.infra.jpa.ConcertHallJpaRepository;
@@ -23,13 +22,8 @@ public class ConcertHallRepositoryImpl implements ConcertHallRepository {
     }
 
     @Override
-    public Optional<ConcertHall> findByHallCode(final String hallCode) {
+    public Optional<ConcertHall> findById(final String hallCode) {
         return jpa.findById(hallCode);
-    }
-
-    @Override
-    public ConcertHallDetailResponse findDetailByHallCode(final String hallCode) {
-        return jpa.findById(hallCode).map(ConcertHallDetailResponse::from).orElse(null);
     }
 
     @Override

--- a/src/main/java/com/backend/allreva/module/concert/place/infra/ConcertHallRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/infra/ConcertHallRepositoryImpl.java
@@ -1,14 +1,9 @@
 package com.backend.allreva.module.concert.place.infra;
 
-import static com.backend.allreva.module.concert.place.domain.QConcertHall.concertHall;
-
 import com.backend.allreva.module.concert.place.application.dto.ConcertHallDetailResponse;
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
 import com.backend.allreva.module.concert.place.infra.jpa.ConcertHallJpaRepository;
-import com.querydsl.core.types.ConstructorExpression;
-import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -21,7 +16,6 @@ import org.springframework.stereotype.Repository;
 public class ConcertHallRepositoryImpl implements ConcertHallRepository {
 
     private final ConcertHallJpaRepository jpa;
-    private final JPAQueryFactory queryFactory;
 
     @Override
     public ConcertHall save(final ConcertHall concertHallEntity) {
@@ -29,13 +23,13 @@ public class ConcertHallRepositoryImpl implements ConcertHallRepository {
     }
 
     @Override
-    public Optional<ConcertHall> findByHallCodeWithLock(final String hallCode) {
-        return jpa.findByHallCodeWithLock(hallCode);
+    public Optional<ConcertHall> findByHallCode(final String hallCode) {
+        return jpa.findById(hallCode);
     }
 
     @Override
-    public Optional<ConcertHall> findByHallCode(final String hallCode) {
-        return jpa.findById(hallCode);
+    public ConcertHallDetailResponse findDetailByHallCode(final String hallCode) {
+        return jpa.findById(hallCode).map(ConcertHallDetailResponse::from).orElse(null);
     }
 
     @Override
@@ -56,23 +50,5 @@ public class ConcertHallRepositoryImpl implements ConcertHallRepository {
     @Override
     public Set<String> findHallCodesByFacilityCode(final String facilityCode) {
         return new HashSet<>(jpa.findHallCodesByFacilityCode(facilityCode));
-    }
-
-    @Override
-    public ConcertHallDetailResponse findDetailByHallCode(final String hallCode) {
-        return queryFactory
-                .select(hallDetailProjections())
-                .from(concertHall)
-                .where(concertHall.hallCode.eq(hallCode))
-                .fetchFirst();
-    }
-
-    private static ConstructorExpression<ConcertHallDetailResponse> hallDetailProjections() {
-        return Projections.constructor(
-                ConcertHallDetailResponse.class,
-                concertHall.name,
-                concertHall.seatScale,
-                concertHall.convenienceInfo,
-                concertHall.location);
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/place/infra/jpa/ConcertHallJpaRepository.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/infra/jpa/ConcertHallJpaRepository.java
@@ -1,19 +1,12 @@
 package com.backend.allreva.module.concert.place.infra.jpa;
 
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
-import jakarta.persistence.LockModeType;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ConcertHallJpaRepository extends JpaRepository<ConcertHall, String> {
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT c FROM ConcertHall c WHERE c.hallCode = :hallCode")
-    Optional<ConcertHall> findByHallCodeWithLock(@Param("hallCode") String hallCode);
 
     @Query("SELECT c.hallCode FROM ConcertHall c")
     List<String> findAllHallCodes();

--- a/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallController.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallController.java
@@ -3,8 +3,6 @@ package com.backend.allreva.module.concert.place.presentation;
 import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.concert.place.application.HallService;
 import com.backend.allreva.module.concert.place.application.dto.ConcertHallDetailResponse;
-import com.backend.allreva.module.concert.place.application.dto.RelatedConcertResponse;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,11 +18,5 @@ public class ConcertHallController implements ConcertHallControllerSwagger {
     public Response<ConcertHallDetailResponse> findHallDetailByHallCode(final String hallCode) {
         ConcertHallDetailResponse details = hallService.findDetailByHallCode(hallCode);
         return Response.onSuccess(details);
-    }
-
-    @Override
-    public Response<List<RelatedConcertResponse>> findRelatedConcertList(
-            final String hallCode, final String lastConcertCode, final int pageSize) {
-        return Response.onSuccess(hallService.getRelatedConcert(hallCode, lastConcertCode, pageSize));
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallController.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallController.java
@@ -1,22 +1,28 @@
 package com.backend.allreva.module.concert.place.presentation;
 
 import com.backend.allreva.common.web.response.Response;
-import com.backend.allreva.module.concert.place.application.HallService;
+import com.backend.allreva.module.concert.place.application.ConcertHallService;
 import com.backend.allreva.module.concert.place.application.dto.ConcertHallDetailResponse;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/concert-halls")
 @RestController
+@Validated
 public class ConcertHallController implements ConcertHallControllerSwagger {
 
-    private final HallService hallService;
+    private final ConcertHallService concertHallService;
 
     @Override
-    public Response<ConcertHallDetailResponse> findHallDetailByHallCode(final String hallCode) {
-        ConcertHallDetailResponse details = hallService.findDetailByHallCode(hallCode);
-        return Response.onSuccess(details);
+    @GetMapping("/{hallCode}")
+    public Response<ConcertHallDetailResponse> getConcertHallDetail(
+            @NotBlank @PathVariable("hallCode") final String hallCode) {
+        return Response.onSuccess(concertHallService.getConcertHallDetail(hallCode));
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallControllerSwagger.java
@@ -4,13 +4,11 @@ import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.concert.place.application.dto.ConcertHallDetailResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "공연장 API", description = "공연장 관련 API")
 public interface ConcertHallControllerSwagger {
 
     @Operation(summary = "공연장 상세 조회", description = "공연장 상세 조회 API")
-    @GetMapping("/{hallCode}")
-    Response<ConcertHallDetailResponse> findHallDetailByHallCode(@PathVariable("hallCode") String hallCode);
+    Response<ConcertHallDetailResponse> getConcertHallDetail(@PathVariable("hallCode") String hallCode);
 }

--- a/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallControllerSwagger.java
@@ -2,13 +2,10 @@ package com.backend.allreva.module.concert.place.presentation;
 
 import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.concert.place.application.dto.ConcertHallDetailResponse;
-import com.backend.allreva.module.concert.place.application.dto.RelatedConcertResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "공연장 API", description = "공연장 관련 API")
 public interface ConcertHallControllerSwagger {
@@ -16,11 +13,4 @@ public interface ConcertHallControllerSwagger {
     @Operation(summary = "공연장 상세 조회", description = "공연장 상세 조회 API")
     @GetMapping("/{hallCode}")
     Response<ConcertHallDetailResponse> findHallDetailByHallCode(@PathVariable("hallCode") String hallCode);
-
-    @Operation(summary = "콘서트 홀에 관련 공연 API", description = "콘서트 홀에 관련 공연 API 무한 스크롤")
-    @GetMapping("/relate/list")
-    Response<List<RelatedConcertResponse>> findRelatedConcertList(
-            @RequestParam(required = true) String hallCode,
-            @RequestParam(required = false) String lastConcertCode,
-            @RequestParam(defaultValue = "3") int pageSize);
 }

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/application/RentService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/application/RentService.java
@@ -67,7 +67,7 @@ public class RentService {
         Rent rent = rentRepository.findById(id).orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
         Concert concert = concertRepository.findById(rent.getConcertCode()).orElse(null);
         ConcertHall concertHall = concert != null
-                ? concertHallRepository.findByHallCode(concert.getHallCode()).orElse(null)
+                ? concertHallRepository.findById(concert.getHallCode()).orElse(null)
                 : null;
         return RentDetailResponse.from(rent, concert, concertHall);
     }

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/application/SurveyService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/application/SurveyService.java
@@ -2,7 +2,7 @@ package com.backend.allreva.module.recruitment.survey.application;
 
 import com.backend.allreva.common.event.Events;
 import com.backend.allreva.common.exception.CustomException;
-import com.backend.allreva.module.concert.concert.application.dto.ConcertDateInfoResponse;
+import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
 import com.backend.allreva.module.concert.concert.exception.ConcertErrorCode;
 import com.backend.allreva.module.notification.domain.event.NotificationEvent;
@@ -167,22 +167,15 @@ public class SurveyService {
     }
 
     private void validateBoardingDates(final String concertCode, final List<LocalDate> boardingDates) {
-        ConcertDateInfoResponse dateInfo = findStartDateAndEndDateById(concertCode);
+        Concert concert = concertRepository
+                .findById(concertCode)
+                .orElseThrow(() -> new CustomException(ConcertErrorCode.CONCERT_NOT_FOUND));
 
-        LocalDate concertStartDate = dateInfo.getStartDate();
-        LocalDate concertEndDate = dateInfo.getEndDate();
-
-        for (LocalDate boardingDate : boardingDates) {
-            if (boardingDate.isBefore(concertStartDate) || boardingDate.isAfter(concertEndDate)) {
+        boardingDates.forEach(date -> {
+            if (!concert.isValidBoardingDate(date)) {
                 throw new CustomException(SurveyErrorCode.SURVEY_INVALID_BOARDING_DATE);
             }
-        }
-    }
-
-    private ConcertDateInfoResponse findStartDateAndEndDateById(final String concertCode) {
-        return concertRepository
-                .findStartDateAndEndDateById(concertCode)
-                .orElseThrow(() -> new CustomException(ConcertErrorCode.CONCERT_NOT_FOUND));
+        });
     }
 
     private Survey findSurvey(final Long surveyId) {

--- a/src/test/java/com/backend/allreva/module/concert/concert/fixture/ConcertFixture.java
+++ b/src/test/java/com/backend/allreva/module/concert/concert/fixture/ConcertFixture.java
@@ -135,4 +135,25 @@ public final class ConcertFixture {
                 .sellers(Set.of())
                 .build();
     }
+
+    public static Concert createConcertWithoutPoster(final String concertCode, final String hallCode) {
+        return Concert.builder()
+                .concertCode(concertCode)
+                .hallCode(hallCode)
+                .concertInfo(ConcertInfo.builder()
+                        .title("포스터 없는 공연")
+                        .price("price")
+                        .performStatus(ConcertStatus.IN_PROGRESS)
+                        .host("host")
+                        .dateInfo(DateInfo.builder()
+                                .startDate(LocalDate.of(2030, 12, 1))
+                                .endDate(LocalDate.of(2030, 12, 2))
+                                .timeTable("timetable")
+                                .build())
+                        .build())
+                .poster(null)
+                .detailImages(List.of())
+                .sellers(Set.of())
+                .build();
+    }
 }

--- a/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertIntegrationTest.java
@@ -1,16 +1,21 @@
 package com.backend.allreva.module.concert.concert.integration;
 
+import static com.backend.allreva.module.concert.concert.fixture.ConcertFixture.createConcertWithCodes;
 import static com.backend.allreva.module.concert.concert.fixture.ConcertFixture.createConcertWithHallCode;
+import static com.backend.allreva.module.concert.concert.fixture.ConcertFixture.createConcertWithoutPoster;
 import static com.backend.allreva.module.concert.place.fixture.ConcertHallFixture.createTestConcertHall;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.backend.allreva.module.concert.concert.application.ConcertService;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
+import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
 import com.backend.allreva.support.IntegrationTestSupport;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -34,6 +39,121 @@ class ConcertIntegrationTest extends IntegrationTestSupport {
     void tearDown() {
         concertRepository.deleteAll();
         concertHallRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("관련 공연 조회")
+    class Describe_관련_공연_조회 {
+
+        @Nested
+        @DisplayName("같은 공연장의 공연이 여러 개 있을 때")
+        class Context_같은_공연장_공연이_여러_개 {
+
+            @Test
+            @DisplayName("hallCode에 해당하는 공연만 반환된다")
+            void hallCode에_해당하는_공연만_반환된다() {
+                // given
+                concertRepository.save(createConcertWithCodes("PF0001", "HALL-A"));
+                concertRepository.save(createConcertWithCodes("PF0002", "HALL-A"));
+                concertRepository.save(createConcertWithCodes("PF0003", "HALL-B"));
+
+                // when
+                List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-A", null, 10);
+
+                // then
+                assertThat(result).hasSize(2);
+                assertThat(result).extracting(RelatedConcertResponse::concertCode)
+                        .containsExactlyInAnyOrder("PF0001", "PF0002");
+            }
+
+            @Test
+            @DisplayName("pageSize만큼만 반환된다")
+            void pageSize만큼만_반환된다() {
+                // given
+                concertRepository.save(createConcertWithCodes("PF0001", "HALL-C"));
+                concertRepository.save(createConcertWithCodes("PF0002", "HALL-C"));
+                concertRepository.save(createConcertWithCodes("PF0003", "HALL-C"));
+
+                // when
+                List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-C", null, 2);
+
+                // then
+                assertThat(result).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("concertCode 내림차순으로 반환된다")
+            void concertCode_내림차순으로_반환된다() {
+                // given
+                concertRepository.save(createConcertWithCodes("PF0001", "HALL-D"));
+                concertRepository.save(createConcertWithCodes("PF0003", "HALL-D"));
+                concertRepository.save(createConcertWithCodes("PF0002", "HALL-D"));
+
+                // when
+                List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-D", null, 10);
+
+                // then
+                assertThat(result).extracting(RelatedConcertResponse::concertCode)
+                        .containsExactly("PF0003", "PF0002", "PF0001");
+            }
+        }
+
+        @Nested
+        @DisplayName("커서 기반 페이징이 적용될 때")
+        class Context_커서_페이징 {
+
+            @Test
+            @DisplayName("lastConcertCode보다 작은 concertCode의 공연만 반환된다")
+            void lastConcertCode_이전_공연만_반환된다() {
+                // given
+                concertRepository.save(createConcertWithCodes("PF0001", "HALL-E"));
+                concertRepository.save(createConcertWithCodes("PF0002", "HALL-E"));
+                concertRepository.save(createConcertWithCodes("PF0003", "HALL-E"));
+
+                // when
+                List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-E", "PF0003", 10);
+
+                // then
+                assertThat(result).extracting(RelatedConcertResponse::concertCode)
+                        .containsExactly("PF0002", "PF0001");
+            }
+        }
+
+        @Nested
+        @DisplayName("poster가 없는 공연이 있을 때")
+        class Context_poster가_없는_공연 {
+
+            @Test
+            @DisplayName("posterUrl이 null로 매핑된다")
+            void posterUrl이_null로_매핑된다() {
+                // given
+                concertRepository.save(createConcertWithoutPoster("PF0001", "HALL-F"));
+
+                // when
+                List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-F", null, 10);
+
+                // then
+                assertSoftly(softly -> {
+                    softly.assertThat(result).hasSize(1);
+                    softly.assertThat(result.get(0).posterUrl()).isNull();
+                });
+            }
+        }
+
+        @Nested
+        @DisplayName("해당 공연장의 공연이 없을 때")
+        class Context_공연이_없을_때 {
+
+            @Test
+            @DisplayName("빈 리스트가 반환된다")
+            void 빈_리스트가_반환된다() {
+                // when
+                List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-EMPTY", null, 10);
+
+                // then
+                assertThat(result).isEmpty();
+            }
+        }
     }
 
     @Nested

--- a/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertIntegrationTest.java
@@ -62,7 +62,8 @@ class ConcertIntegrationTest extends IntegrationTestSupport {
 
                 // then
                 assertThat(result).hasSize(2);
-                assertThat(result).extracting(RelatedConcertResponse::concertCode)
+                assertThat(result)
+                        .extracting(RelatedConcertResponse::concertCode)
                         .containsExactlyInAnyOrder("PF0001", "PF0002");
             }
 
@@ -93,7 +94,8 @@ class ConcertIntegrationTest extends IntegrationTestSupport {
                 List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-D", null, 10);
 
                 // then
-                assertThat(result).extracting(RelatedConcertResponse::concertCode)
+                assertThat(result)
+                        .extracting(RelatedConcertResponse::concertCode)
                         .containsExactly("PF0003", "PF0002", "PF0001");
             }
         }
@@ -114,7 +116,8 @@ class ConcertIntegrationTest extends IntegrationTestSupport {
                 List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-E", "PF0003", 10);
 
                 // then
-                assertThat(result).extracting(RelatedConcertResponse::concertCode)
+                assertThat(result)
+                        .extracting(RelatedConcertResponse::concertCode)
                         .containsExactly("PF0002", "PF0001");
             }
         }

--- a/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertSyncIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertSyncIntegrationTest.java
@@ -285,8 +285,7 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
                 concertHallSyncScheduler.fetchConcertHallInfoList();
 
                 // then
-                ConcertHall result =
-                        concertHallRepository.findByHallCode(HALL_ID).orElseThrow();
+                ConcertHall result = concertHallRepository.findById(HALL_ID).orElseThrow();
                 assertSoftly(softly -> {
                     softly.assertThat(result.getName()).isEqualTo("업데이트된 공연장");
                     softly.assertThat(result.getSeatScale()).isEqualTo(20000);
@@ -345,8 +344,8 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
                 concertHallSyncScheduler.fetchConcertHallInfoList();
 
                 // then
-                assertThat(concertHallRepository.findByHallCode("FC001114-2")).isEmpty();
-                assertThat(concertHallRepository.findByHallCode(HALL_ID)).isPresent();
+                assertThat(concertHallRepository.findById("FC001114-2")).isEmpty();
+                assertThat(concertHallRepository.findById(HALL_ID)).isPresent();
             }
         }
 


### PR DESCRIPTION
## 작업 내용

Concert·place infra 레이어 정리. `HallService`가 `ConcertRepository`를 직접 호출하는
역방향 의존(place → concert) 제거가 주요 변경.

## 구현

**미사용 메서드 제거**
- `ConcertRepository`: `findDetailById`, `findStartDateAndEndDateById`, `getConcertMainThumbnails`, `deleteAllInBatch`
- `ConcertHallRepository`: `findDetailByHallCode`, `findByHallCodeWithLock`

**의존 방향 수정**
- `RelatedConcertResponse` `place.dto` → `concert.dto` 이동
- 관련 공연 조회 로직 `HallService` → `ConcertService`로 이동
- 엔드포인트 `/concert-halls/relate/list` → `GET /concerts?hallCode=`

**서비스 레이어로 이동**
- `findDetailById` 공연+공연장 조합 로직 infra → `ConcertService`
- 날짜 유효성 검증 `SurveyService` → `Concert.isValidBoardingDate()` 도메인 메서드

**기타**
- `ConcertRepository` 도메인 인터페이스에서 application DTO 의존 제거
- `HallService` → `ConcertHallService` 이름 변경
- `hallCode @NotBlank`, `pageSize @Positive` 검증 추가

## 테스트

통합 테스트 패스 확인.

Closes #44