### PR TITLE
[#48] util/converter 추상 클래스 common/converter로 이동

### DIFF
--- a/src/main/java/com/backend/allreva/common/converter/AbstractJsonListConverter.java
+++ b/src/main/java/com/backend/allreva/common/converter/AbstractJsonListConverter.java
@@ -1,14 +1,14 @@
-package com.backend.allreva.util.converter;
+package com.backend.allreva.common.converter;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.AttributeConverter;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
-public abstract class AbstractJsonSetConverter<T> implements AttributeConverter<Set<T>, String> {
+public abstract class AbstractJsonListConverter<T> implements AttributeConverter<List<T>, String> {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
@@ -17,32 +17,32 @@ public abstract class AbstractJsonSetConverter<T> implements AttributeConverter<
 
     private final Class<T> elementType;
 
-    protected AbstractJsonSetConverter(final Class<T> elementType) {
+    protected AbstractJsonListConverter(final Class<T> elementType) {
         this.elementType = elementType;
     }
 
     @Override
-    public String convertToDatabaseColumn(final Set<T> set) {
-        if (set == null || set.isEmpty()) {
+    public String convertToDatabaseColumn(final List<T> list) {
+        if (list == null || list.isEmpty()) {
             return "[]";
         }
         try {
-            return OBJECT_MAPPER.writeValueAsString(set);
+            return OBJECT_MAPPER.writeValueAsString(list);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("Set을 JSON으로 변환하는 데 실패했습니다.", e);
+            throw new RuntimeException("List를 JSON으로 변환하는 데 실패했습니다.", e);
         }
     }
 
     @Override
-    public Set<T> convertToEntityAttribute(final String json) {
+    public List<T> convertToEntityAttribute(final String json) {
         if (json == null || json.isBlank()) {
-            return new HashSet<>();
+            return new ArrayList<>();
         }
         try {
             return OBJECT_MAPPER.readValue(
-                    json, OBJECT_MAPPER.getTypeFactory().constructCollectionType(Set.class, elementType));
+                    json, OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, elementType));
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("JSON을 Set으로 변환하는 데 실패했습니다.", e);
+            throw new RuntimeException("JSON을 List로 변환하는 데 실패했습니다.", e);
         }
     }
 }

--- a/src/main/java/com/backend/allreva/common/converter/AbstractJsonSetConverter.java
+++ b/src/main/java/com/backend/allreva/common/converter/AbstractJsonSetConverter.java
@@ -1,14 +1,14 @@
-package com.backend.allreva.util.converter;
+package com.backend.allreva.common.converter;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.AttributeConverter;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
-public abstract class AbstractJsonListConverter<T> implements AttributeConverter<List<T>, String> {
+public abstract class AbstractJsonSetConverter<T> implements AttributeConverter<Set<T>, String> {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
@@ -17,32 +17,32 @@ public abstract class AbstractJsonListConverter<T> implements AttributeConverter
 
     private final Class<T> elementType;
 
-    protected AbstractJsonListConverter(final Class<T> elementType) {
+    protected AbstractJsonSetConverter(final Class<T> elementType) {
         this.elementType = elementType;
     }
 
     @Override
-    public String convertToDatabaseColumn(final List<T> list) {
-        if (list == null || list.isEmpty()) {
+    public String convertToDatabaseColumn(final Set<T> set) {
+        if (set == null || set.isEmpty()) {
             return "[]";
         }
         try {
-            return OBJECT_MAPPER.writeValueAsString(list);
+            return OBJECT_MAPPER.writeValueAsString(set);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("List를 JSON으로 변환하는 데 실패했습니다.", e);
+            throw new RuntimeException("Set을 JSON으로 변환하는 데 실패했습니다.", e);
         }
     }
 
     @Override
-    public List<T> convertToEntityAttribute(final String json) {
+    public Set<T> convertToEntityAttribute(final String json) {
         if (json == null || json.isBlank()) {
-            return new ArrayList<>();
+            return new HashSet<>();
         }
         try {
             return OBJECT_MAPPER.readValue(
-                    json, OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, elementType));
+                    json, OBJECT_MAPPER.getTypeFactory().constructCollectionType(Set.class, elementType));
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("JSON을 List로 변환하는 데 실패했습니다.", e);
+            throw new RuntimeException("JSON을 Set으로 변환하는 데 실패했습니다.", e);
         }
     }
 }

--- a/src/main/java/com/backend/allreva/common/converter/ImageListConverter.java
+++ b/src/main/java/com/backend/allreva/common/converter/ImageListConverter.java
@@ -1,7 +1,6 @@
 package com.backend.allreva.common.converter;
 
 import com.backend.allreva.common.model.Image;
-import com.backend.allreva.util.converter.AbstractJsonListConverter;
 import jakarta.persistence.Converter;
 
 @Converter

--- a/src/main/java/com/backend/allreva/module/concert/concert/infra/jpa/SellerSetConverter.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/infra/jpa/SellerSetConverter.java
@@ -1,7 +1,7 @@
 package com.backend.allreva.module.concert.concert.infra.jpa;
 
+import com.backend.allreva.common.converter.AbstractJsonSetConverter;
 import com.backend.allreva.module.concert.concert.domain.value.Seller;
-import com.backend.allreva.util.converter.AbstractJsonSetConverter;
 import jakarta.persistence.Converter;
 
 @Converter

--- a/src/test/java/com/backend/allreva/common/converter/JsonConverterIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/common/converter/JsonConverterIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.backend.allreva.util.converter;
+package com.backend.allreva.common.converter;
 
 import static com.backend.allreva.module.concert.concert.fixture.ConcertFixture.createTestConcert;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;


### PR DESCRIPTION
## 작업 내용

`util/converter/`에 있던 `AbstractJsonListConverter`, `AbstractJsonSetConverter`가
이미 모듈 infra에 배치된 `SellerSetConverter`, `RefundAccountConverter`와 위치 일관성이 없었음.
추상 클래스를 `common/converter/`로 흡수하고 `util/converter` 패키지 제거.

## 구현

- `AbstractJsonListConverter`, `AbstractJsonSetConverter` → `common/converter/`로 이동
- `ImageListConverter`: 같은 패키지가 되어 import 제거
- `SellerSetConverter`: import 경로 `util` → `common`으로 변경
- `JsonConverterIntegrationTest`: 패키지 경로 `util/converter` → `common/converter`로 이동

## 테스트

테스트 전체 통과

Closes #48