### PR TITLE
[#49] Instancio 도입으로 테스트 픽스처 Object Mother 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     // test
+    testImplementation 'org.instancio:instancio-junit:5.5.1'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:4.1.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/test/java/com/backend/allreva/common/converter/JsonConverterIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/common/converter/JsonConverterIntegrationTest.java
@@ -37,7 +37,8 @@ class JsonConverterIntegrationTest extends IntegrationTestSupport {
             @DisplayName("detailImages가 jsonb 컬럼에 정상 저장되고 조회된다")
             void detailImages_저장_조회() {
                 // given
-                Concert concert = Instancio.of(ConcertFixture.inProgressConcertModel()).create();
+                Concert concert =
+                        Instancio.of(ConcertFixture.inProgressConcertModel()).create();
 
                 // when
                 Concert saved = concertRepository.save(concert);
@@ -67,7 +68,8 @@ class JsonConverterIntegrationTest extends IntegrationTestSupport {
             @DisplayName("sellers가 jsonb 컬럼에 정상 저장되고 조회된다")
             void sellers_저장_조회() {
                 // given
-                Concert concert = Instancio.of(ConcertFixture.inProgressConcertModel()).create();
+                Concert concert =
+                        Instancio.of(ConcertFixture.inProgressConcertModel()).create();
 
                 // when
                 Concert saved = concertRepository.save(concert);

--- a/src/test/java/com/backend/allreva/common/converter/JsonConverterIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/common/converter/JsonConverterIntegrationTest.java
@@ -1,11 +1,12 @@
 package com.backend.allreva.common.converter;
 
-import static com.backend.allreva.module.concert.concert.fixture.ConcertFixture.createTestConcert;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
+import com.backend.allreva.module.concert.concert.fixture.ConcertFixture;
 import com.backend.allreva.support.IntegrationTestSupport;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -36,7 +37,7 @@ class JsonConverterIntegrationTest extends IntegrationTestSupport {
             @DisplayName("detailImages가 jsonb 컬럼에 정상 저장되고 조회된다")
             void detailImages_저장_조회() {
                 // given
-                Concert concert = createTestConcert();
+                Concert concert = Instancio.of(ConcertFixture.inProgressConcertModel()).create();
 
                 // when
                 Concert saved = concertRepository.save(concert);
@@ -66,7 +67,7 @@ class JsonConverterIntegrationTest extends IntegrationTestSupport {
             @DisplayName("sellers가 jsonb 컬럼에 정상 저장되고 조회된다")
             void sellers_저장_조회() {
                 // given
-                Concert concert = createTestConcert();
+                Concert concert = Instancio.of(ConcertFixture.inProgressConcertModel()).create();
 
                 // when
                 Concert saved = concertRepository.save(concert);

--- a/src/test/java/com/backend/allreva/module/concert/concert/fixture/ConcertFixture.java
+++ b/src/test/java/com/backend/allreva/module/concert/concert/fixture/ConcertFixture.java
@@ -1,159 +1,41 @@
 package com.backend.allreva.module.concert.concert.fixture;
 
-import com.backend.allreva.common.model.Image;
+import static org.instancio.Select.field;
+
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.value.ConcertInfo;
 import com.backend.allreva.module.concert.concert.domain.value.ConcertStatus;
 import com.backend.allreva.module.concert.concert.domain.value.DateInfo;
-import com.backend.allreva.module.concert.concert.domain.value.Seller;
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Set;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.instancio.Instancio;
+import org.instancio.Model;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ConcertFixture {
 
-    public static Concert createTestConcert() {
-        return Concert.builder()
-                .concertCode("PFMOCK001")
-                .hallCode("FCMOCK01-1")
-                .concertInfo(ConcertInfo.builder()
-                        .title("Sample Concert")
-                        .price("price")
-                        .performStatus(ConcertStatus.IN_PROGRESS)
-                        .host("host")
-                        .dateInfo(DateInfo.builder()
-                                .startDate(LocalDate.of(2030, 12, 1))
-                                .endDate(LocalDate.of(2030, 12, 2))
-                                .timeTable("timetable")
-                                .build())
-                        .build())
-                .poster(new Image("http://example.com/poster.jpg"))
-                .detailImages(List.of(
-                        new Image("http://example.com/detail1.jpg"), new Image("http://example.com/detail2.jpg")))
-                .sellers(Set.of(Seller.builder()
-                        .name("Sample Seller")
-                        .salesUrl("http://seller.com")
-                        .build()))
-                .build();
+    public static Model<Concert> inProgressConcertModel() {
+        return Instancio.of(Concert.class)
+                .set(field(ConcertInfo.class, "performStatus"), ConcertStatus.IN_PROGRESS)
+                .set(field(DateInfo.class, "startDate"), LocalDate.now().minusDays(10))
+                .set(field(DateInfo.class, "endDate"), LocalDate.now().plusDays(10))
+                .toModel();
     }
 
-    public static Concert createConcertWithHallCode(String hallCode) {
-        return createConcertWithCodes("PFMOCK001", hallCode);
+    public static Model<Concert> completedConcertModel() {
+        return Instancio.of(Concert.class)
+                .set(field(ConcertInfo.class, "performStatus"), ConcertStatus.COMPLETED)
+                .set(field(DateInfo.class, "startDate"), LocalDate.of(2025, 1, 1))
+                .set(field(DateInfo.class, "endDate"), LocalDate.of(2025, 3, 1))
+                .toModel();
     }
 
-    public static Concert createConcertWithCodes(String concertCode, String hallCode) {
-        return Concert.builder()
-                .concertCode(concertCode)
-                .hallCode(hallCode)
-                .concertInfo(ConcertInfo.builder()
-                        .title("Sample Concert")
-                        .price("price")
-                        .performStatus(ConcertStatus.IN_PROGRESS)
-                        .host("host")
-                        .dateInfo(DateInfo.builder()
-                                .startDate(LocalDate.of(2030, 12, 1))
-                                .endDate(LocalDate.of(2030, 12, 2))
-                                .timeTable("timetable")
-                                .build())
-                        .build())
-                .poster(new Image("http://example.com/poster.jpg"))
-                .detailImages(List.of(
-                        new Image("http://example.com/detail1.jpg"), new Image("http://example.com/detail2.jpg")))
-                .sellers(Set.of(Seller.builder()
-                        .name("Sample Seller")
-                        .salesUrl("http://seller.com")
-                        .build()))
-                .build();
-    }
-
-    public static Concert createCompletedConcert(final String concertCode) {
-        return Concert.builder()
-                .concertCode(concertCode)
-                .hallCode("FC001114-1")
-                .concertInfo(ConcertInfo.builder()
-                        .title("종료된 공연")
-                        .performStatus(ConcertStatus.COMPLETED)
-                        .dateInfo(DateInfo.builder()
-                                .startDate(LocalDate.of(2025, 1, 1))
-                                .endDate(LocalDate.of(2025, 3, 1))
-                                .timeTable("토 19:00")
-                                .build())
-                        .host("소속사")
-                        .price("VIP 150,000원")
-                        .build())
-                .poster(new Image("https://poster.jpg"))
-                .detailImages(List.of())
-                .sellers(Set.of())
-                .build();
-    }
-
-    public static Concert createInProgressConcert(final String concertCode) {
-        return createInProgressConcertWithTitle(concertCode, "진행 중인 공연");
-    }
-
-    public static Concert createInProgressConcertWithTitle(final String concertCode, final String title) {
-        return Concert.builder()
-                .concertCode(concertCode)
-                .hallCode("FC001114-1")
-                .concertInfo(ConcertInfo.builder()
-                        .title(title)
-                        .performStatus(ConcertStatus.IN_PROGRESS)
-                        .dateInfo(DateInfo.builder()
-                                .startDate(LocalDate.now().minusDays(10))
-                                .endDate(LocalDate.now().plusDays(10))
-                                .timeTable("토 19:00")
-                                .build())
-                        .host("소속사")
-                        .price("VIP 150,000원")
-                        .build())
-                .poster(new Image("https://poster.jpg"))
-                .detailImages(List.of())
-                .sellers(Set.of())
-                .build();
-    }
-
-    public static Concert createScheduledConcert(final String concertCode) {
-        return Concert.builder()
-                .concertCode(concertCode)
-                .hallCode("FC001114-1")
-                .concertInfo(ConcertInfo.builder()
-                        .title("공연 예정")
-                        .performStatus(ConcertStatus.SCHEDULED)
-                        .dateInfo(DateInfo.builder()
-                                .startDate(LocalDate.now().plusDays(30))
-                                .endDate(LocalDate.now().plusDays(60))
-                                .timeTable("토 19:00")
-                                .build())
-                        .host("소속사")
-                        .price("VIP 150,000원")
-                        .build())
-                .poster(new Image("https://poster.jpg"))
-                .detailImages(List.of())
-                .sellers(Set.of())
-                .build();
-    }
-
-    public static Concert createConcertWithoutPoster(final String concertCode, final String hallCode) {
-        return Concert.builder()
-                .concertCode(concertCode)
-                .hallCode(hallCode)
-                .concertInfo(ConcertInfo.builder()
-                        .title("포스터 없는 공연")
-                        .price("price")
-                        .performStatus(ConcertStatus.IN_PROGRESS)
-                        .host("host")
-                        .dateInfo(DateInfo.builder()
-                                .startDate(LocalDate.of(2030, 12, 1))
-                                .endDate(LocalDate.of(2030, 12, 2))
-                                .timeTable("timetable")
-                                .build())
-                        .build())
-                .poster(null)
-                .detailImages(List.of())
-                .sellers(Set.of())
-                .build();
+    public static Model<Concert> scheduledConcertModel() {
+        return Instancio.of(Concert.class)
+                .set(field(ConcertInfo.class, "performStatus"), ConcertStatus.SCHEDULED)
+                .set(field(DateInfo.class, "startDate"), LocalDate.now().plusDays(30))
+                .set(field(DateInfo.class, "endDate"), LocalDate.now().plusDays(60))
+                .toModel();
     }
 }

--- a/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertIntegrationTest.java
@@ -225,7 +225,8 @@ class ConcertIntegrationTest extends IntegrationTestSupport {
                     softly.assertThat(result).isNotNull();
                     softly.assertThat(result.hallCode()).isEqualTo(hall.getHallCode());
                     softly.assertThat(result.hallName()).isEqualTo(hall.getName());
-                    softly.assertThat(result.concertInfo().getTitle()).isEqualTo(concert.getConcertInfo().getTitle());
+                    softly.assertThat(result.concertInfo().getTitle())
+                            .isEqualTo(concert.getConcertInfo().getTitle());
                     softly.assertThat(result.sellers()).isNotEmpty();
                     softly.assertThat(result.convenienceInfo()).isNotNull();
                 });

--- a/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertIntegrationTest.java
@@ -1,21 +1,21 @@
 package com.backend.allreva.module.concert.concert.integration;
 
-import static com.backend.allreva.module.concert.concert.fixture.ConcertFixture.createConcertWithCodes;
-import static com.backend.allreva.module.concert.concert.fixture.ConcertFixture.createConcertWithHallCode;
-import static com.backend.allreva.module.concert.concert.fixture.ConcertFixture.createConcertWithoutPoster;
-import static com.backend.allreva.module.concert.place.fixture.ConcertHallFixture.createTestConcertHall;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.instancio.Select.field;
 
 import com.backend.allreva.module.concert.concert.application.ConcertService;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
+import com.backend.allreva.module.concert.concert.fixture.ConcertFixture;
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
+import com.backend.allreva.module.concert.place.fixture.ConcertHallFixture;
 import com.backend.allreva.support.IntegrationTestSupport;
 import java.util.List;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -53,9 +53,18 @@ class ConcertIntegrationTest extends IntegrationTestSupport {
             @DisplayName("hallCode에 해당하는 공연만 반환된다")
             void hallCode에_해당하는_공연만_반환된다() {
                 // given
-                concertRepository.save(createConcertWithCodes("PF0001", "HALL-A"));
-                concertRepository.save(createConcertWithCodes("PF0002", "HALL-A"));
-                concertRepository.save(createConcertWithCodes("PF0003", "HALL-B"));
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0001")
+                        .set(field(Concert.class, "hallCode"), "HALL-A")
+                        .create());
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0002")
+                        .set(field(Concert.class, "hallCode"), "HALL-A")
+                        .create());
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0003")
+                        .set(field(Concert.class, "hallCode"), "HALL-B")
+                        .create());
 
                 // when
                 List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-A", null, 10);
@@ -71,9 +80,18 @@ class ConcertIntegrationTest extends IntegrationTestSupport {
             @DisplayName("pageSize만큼만 반환된다")
             void pageSize만큼만_반환된다() {
                 // given
-                concertRepository.save(createConcertWithCodes("PF0001", "HALL-C"));
-                concertRepository.save(createConcertWithCodes("PF0002", "HALL-C"));
-                concertRepository.save(createConcertWithCodes("PF0003", "HALL-C"));
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0001")
+                        .set(field(Concert.class, "hallCode"), "HALL-C")
+                        .create());
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0002")
+                        .set(field(Concert.class, "hallCode"), "HALL-C")
+                        .create());
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0003")
+                        .set(field(Concert.class, "hallCode"), "HALL-C")
+                        .create());
 
                 // when
                 List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-C", null, 2);
@@ -86,9 +104,18 @@ class ConcertIntegrationTest extends IntegrationTestSupport {
             @DisplayName("concertCode 내림차순으로 반환된다")
             void concertCode_내림차순으로_반환된다() {
                 // given
-                concertRepository.save(createConcertWithCodes("PF0001", "HALL-D"));
-                concertRepository.save(createConcertWithCodes("PF0003", "HALL-D"));
-                concertRepository.save(createConcertWithCodes("PF0002", "HALL-D"));
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0001")
+                        .set(field(Concert.class, "hallCode"), "HALL-D")
+                        .create());
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0003")
+                        .set(field(Concert.class, "hallCode"), "HALL-D")
+                        .create());
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0002")
+                        .set(field(Concert.class, "hallCode"), "HALL-D")
+                        .create());
 
                 // when
                 List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-D", null, 10);
@@ -108,9 +135,18 @@ class ConcertIntegrationTest extends IntegrationTestSupport {
             @DisplayName("lastConcertCode보다 작은 concertCode의 공연만 반환된다")
             void lastConcertCode_이전_공연만_반환된다() {
                 // given
-                concertRepository.save(createConcertWithCodes("PF0001", "HALL-E"));
-                concertRepository.save(createConcertWithCodes("PF0002", "HALL-E"));
-                concertRepository.save(createConcertWithCodes("PF0003", "HALL-E"));
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0001")
+                        .set(field(Concert.class, "hallCode"), "HALL-E")
+                        .create());
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0002")
+                        .set(field(Concert.class, "hallCode"), "HALL-E")
+                        .create());
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0003")
+                        .set(field(Concert.class, "hallCode"), "HALL-E")
+                        .create());
 
                 // when
                 List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-E", "PF0003", 10);
@@ -130,7 +166,11 @@ class ConcertIntegrationTest extends IntegrationTestSupport {
             @DisplayName("posterUrl이 null로 매핑된다")
             void posterUrl이_null로_매핑된다() {
                 // given
-                concertRepository.save(createConcertWithoutPoster("PF0001", "HALL-F"));
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PF0001")
+                        .set(field(Concert.class, "hallCode"), "HALL-F")
+                        .ignore(field(Concert.class, "poster"))
+                        .create());
 
                 // when
                 List<RelatedConcertResponse> result = concertService.getRelatedConcerts("HALL-F", null, 10);
@@ -171,8 +211,11 @@ class ConcertIntegrationTest extends IntegrationTestSupport {
             @DisplayName("공연 상세 정보와 공연장 정보가 함께 반환된다")
             void 공연_상세_정보와_공연장_정보가_반환된다() {
                 // given
-                ConcertHall hall = concertHallRepository.save(createTestConcertHall());
-                Concert concert = concertRepository.save(createConcertWithHallCode(hall.getHallCode()));
+                ConcertHall hall = concertHallRepository.save(
+                        Instancio.of(ConcertHallFixture.concertHallModel()).create());
+                Concert concert = concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "hallCode"), hall.getHallCode())
+                        .create());
 
                 // when
                 ConcertDetailResponse result = concertService.findDetailById(concert.getConcertCode());
@@ -182,7 +225,7 @@ class ConcertIntegrationTest extends IntegrationTestSupport {
                     softly.assertThat(result).isNotNull();
                     softly.assertThat(result.hallCode()).isEqualTo(hall.getHallCode());
                     softly.assertThat(result.hallName()).isEqualTo(hall.getName());
-                    softly.assertThat(result.concertInfo().getTitle()).isEqualTo("Sample Concert");
+                    softly.assertThat(result.concertInfo().getTitle()).isEqualTo(concert.getConcertInfo().getTitle());
                     softly.assertThat(result.sellers()).isNotEmpty();
                     softly.assertThat(result.convenienceInfo()).isNotNull();
                 });

--- a/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertSyncIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertSyncIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.backend.allreva.module.concert.concert.integration;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static org.instancio.Select.field;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
@@ -11,6 +10,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.instancio.Select.field;
 
 import com.backend.allreva.module.concert.concert.application.ConcertSyncScheduler;
 import com.backend.allreva.module.concert.concert.domain.Concert;
@@ -22,9 +22,9 @@ import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
 import com.backend.allreva.module.concert.place.fixture.ConcertHallFixture;
 import com.backend.allreva.support.IntegrationTestSupport;
-import org.instancio.Instancio;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.time.LocalDate;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertSyncIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertSyncIntegrationTest.java
@@ -1,9 +1,7 @@
 package com.backend.allreva.module.concert.concert.integration;
 
-import static com.backend.allreva.module.concert.concert.fixture.ConcertFixture.createCompletedConcert;
-import static com.backend.allreva.module.concert.concert.fixture.ConcertFixture.createScheduledConcert;
-import static com.backend.allreva.module.concert.place.fixture.ConcertHallFixture.createConcertHall;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static org.instancio.Select.field;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
@@ -17,10 +15,14 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import com.backend.allreva.module.concert.concert.application.ConcertSyncScheduler;
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
+import com.backend.allreva.module.concert.concert.domain.value.ConcertInfo;
+import com.backend.allreva.module.concert.concert.fixture.ConcertFixture;
 import com.backend.allreva.module.concert.place.application.ConcertHallSyncScheduler;
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
+import com.backend.allreva.module.concert.place.fixture.ConcertHallFixture;
 import com.backend.allreva.support.IntegrationTestSupport;
+import org.instancio.Instancio;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.time.LocalDate;
 import org.junit.jupiter.api.AfterEach;
@@ -131,7 +133,9 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             void savesNewConcertToDb() {
                 // given
                 String concertCode = "PF001";
-                concertHallRepository.save(createConcertHall(HALL_ID));
+                concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
+                        .set(field(ConcertHall.class, "hallCode"), HALL_ID)
+                        .create());
 
                 stubFor(get(urlPathEqualTo("/openApi/restful/pblprfr"))
                         .withQueryParam("prfplccd", equalTo(HALL_ID))
@@ -165,8 +169,13 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             void skipsCompletedConcert() {
                 // given
                 String concertCode = "PF003";
-                concertHallRepository.save(createConcertHall(HALL_ID));
-                concertRepository.save(createCompletedConcert(concertCode));
+                concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
+                        .set(field(ConcertHall.class, "hallCode"), HALL_ID)
+                        .create());
+                concertRepository.save(Instancio.of(ConcertFixture.completedConcertModel())
+                        .set(field(Concert.class, "concertCode"), concertCode)
+                        .set(field(ConcertInfo.class, "title"), "종료된 공연")
+                        .create());
 
                 stubFor(get(urlPathEqualTo("/openApi/restful/pblprfr"))
                         .withQueryParam("prfplccd", equalTo(HALL_ID))
@@ -193,8 +202,12 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             void callsDetailAndUpdatesOnStatusTransition() {
                 // given
                 String concertCode = "PF004";
-                concertHallRepository.save(createConcertHall(HALL_ID));
-                concertRepository.save(createScheduledConcert(concertCode));
+                concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
+                        .set(field(ConcertHall.class, "hallCode"), HALL_ID)
+                        .create());
+                concertRepository.save(Instancio.of(ConcertFixture.scheduledConcertModel())
+                        .set(field(Concert.class, "concertCode"), concertCode)
+                        .create());
 
                 stubFor(get(urlPathEqualTo("/openApi/restful/pblprfr"))
                         .withQueryParam("prfplccd", equalTo(HALL_ID))
@@ -247,7 +260,9 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             @DisplayName("공연장 정보를 DB에 업데이트한다")
             void updatesConcertHallInfoInDb() {
                 // given
-                concertHallRepository.save(createConcertHall(HALL_ID));
+                concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
+                        .set(field(ConcertHall.class, "hallCode"), HALL_ID)
+                        .create());
 
                 String updatedHallXml = """
                         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -301,7 +316,9 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             @DisplayName("hallId가 일치하는 공연장만 저장한다")
             void savesOnlyMatchingHalls() {
                 // given
-                concertHallRepository.save(createConcertHall(HALL_ID));
+                concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
+                        .set(field(ConcertHall.class, "hallCode"), HALL_ID)
+                        .create());
 
                 String multiHallXml = """
                         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/src/test/java/com/backend/allreva/module/concert/place/fixture/ConcertHallFixture.java
+++ b/src/test/java/com/backend/allreva/module/concert/place/fixture/ConcertHallFixture.java
@@ -1,49 +1,15 @@
 package com.backend.allreva.module.concert.place.fixture;
 
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
-import com.backend.allreva.module.concert.place.domain.value.ConvenienceInfo;
-import com.backend.allreva.module.concert.place.domain.value.Location;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.instancio.Instancio;
+import org.instancio.Model;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ConcertHallFixture {
 
-    public static ConcertHall createTestConcertHall() {
-        return ConcertHall.builder()
-                .hallCode("hall-001")
-                .name("서울 예술의전당")
-                .seatScale(2500)
-                .convenienceInfo(ConvenienceInfo.builder()
-                        .hasParkingLot(true)
-                        .hasRestaurant(true)
-                        .hasCafe(true)
-                        .hasDisabledParking(true)
-                        .build())
-                .location(Location.builder()
-                        .longitude(127.013079)
-                        .latitude(37.518486)
-                        .address("서울특별시 송파구 올림픽로 424")
-                        .build())
-                .build();
-    }
-
-    public static ConcertHall createConcertHall(String hallCode) {
-        return ConcertHall.builder()
-                .hallCode(hallCode)
-                .name("서울 예술의전당")
-                .seatScale(2500)
-                .convenienceInfo(ConvenienceInfo.builder()
-                        .hasParkingLot(true)
-                        .hasRestaurant(true)
-                        .hasCafe(true)
-                        .hasDisabledParking(true)
-                        .build())
-                .location(Location.builder()
-                        .longitude(127.013079)
-                        .latitude(37.518486)
-                        .address("서울특별시 송파구 올림픽로 424")
-                        .build())
-                .build();
+    public static Model<ConcertHall> concertHallModel() {
+        return Instancio.of(ConcertHall.class).toModel();
     }
 }

--- a/src/test/java/com/backend/allreva/module/concert/place/fixture/ConcertHallFixture.java
+++ b/src/test/java/com/backend/allreva/module/concert/place/fixture/ConcertHallFixture.java
@@ -1,6 +1,10 @@
 package com.backend.allreva.module.concert.place.fixture;
 
+import static org.instancio.Select.allStrings;
+import static org.instancio.Select.field;
+
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
+import com.backend.allreva.module.concert.place.domain.value.Location;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.instancio.Instancio;
@@ -10,6 +14,12 @@ import org.instancio.Model;
 public final class ConcertHallFixture {
 
     public static Model<ConcertHall> concertHallModel() {
-        return Instancio.of(ConcertHall.class).toModel();
+        return Instancio.of(ConcertHall.class)
+                .generate(allStrings(), gen -> gen.string().maxLength(20))
+                .generate(
+                        field(Location.class, "longitude"), gen -> gen.doubles().range(124.0, 132.0))
+                .generate(
+                        field(Location.class, "latitude"), gen -> gen.doubles().range(33.0, 43.0))
+                .toModel();
     }
 }

--- a/src/test/java/com/backend/allreva/module/member/fixture/MemberFixture.java
+++ b/src/test/java/com/backend/allreva/module/member/fixture/MemberFixture.java
@@ -1,12 +1,16 @@
 package com.backend.allreva.module.member.fixture;
 
+import static org.instancio.Select.field;
+
+import com.backend.allreva.common.model.BaseEntity;
 import com.backend.allreva.common.model.Email;
 import com.backend.allreva.module.member.domain.Member;
 import com.backend.allreva.module.member.domain.value.LoginProvider;
 import com.backend.allreva.module.member.domain.value.MemberRole;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.instancio.Instancio;
+import org.instancio.Model;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MemberFixture {
@@ -15,39 +19,37 @@ public final class MemberFixture {
     public static final String OTHER_EMAIL = "other@example.com";
     public static final LoginProvider PROVIDER = LoginProvider.GOOGLE;
 
+    public static Model<Member> memberModel() {
+        return Instancio.of(Member.class)
+                .ignore(field(Member.class, "id"))
+                .ignore(field(BaseEntity.class, "deletedAt"))
+                .set(field(Member.class, "memberRole"), MemberRole.USER)
+                .set(field(Member.class, "loginProvider"), LoginProvider.GOOGLE)
+                .toModel();
+    }
+
     public static Member createTestMember() {
-        return createTestMember(EMAIL, PROVIDER);
+        return Instancio.of(memberModel())
+                .set(field(Email.class, "email"), EMAIL)
+                .create();
     }
 
     public static Member createOtherTestMember() {
-        return createTestMember(OTHER_EMAIL, PROVIDER);
+        return Instancio.of(memberModel())
+                .set(field(Email.class, "email"), OTHER_EMAIL)
+                .create();
     }
 
     public static Member createTestMemberWithIndex(final int index) {
-        return createTestMember("member" + index + "@example.com", PROVIDER);
+        return Instancio.of(memberModel())
+                .set(field(Email.class, "email"), "member" + index + "@example.com")
+                .create();
     }
 
     public static Member createTestMember(final String email, final LoginProvider loginProvider) {
-        return Member.builder()
-                .email(new Email(email))
-                .memberRole(MemberRole.USER)
-                .loginProvider(loginProvider)
-                .nickname("JohnDoe")
-                .introduce("Hello, I'm John.")
-                .profileImageUrl("http://example.com/profile.jpg")
-                .build();
-    }
-
-    public static Member createMember(final Long memberId, final MemberRole memberRole) {
-        var member = Member.builder()
-                .email(Email.builder().email(EMAIL).build())
-                .nickname("testNickname")
-                .memberRole(memberRole)
-                .loginProvider(PROVIDER)
-                .introduce("introduce")
-                .profileImageUrl("https://example.com/profile.jpg")
-                .build();
-        ReflectionTestUtils.setField(member, "id", memberId);
-        return member;
+        return Instancio.of(memberModel())
+                .set(field(Email.class, "email"), email)
+                .set(field(Member.class, "loginProvider"), loginProvider)
+                .create();
     }
 }

--- a/src/test/java/com/backend/allreva/module/member/fixture/MemberRequestFixture.java
+++ b/src/test/java/com/backend/allreva/module/member/fixture/MemberRequestFixture.java
@@ -2,6 +2,7 @@ package com.backend.allreva.module.member.fixture;
 
 import static org.instancio.Select.field;
 
+import com.backend.allreva.common.model.Image;
 import com.backend.allreva.module.member.application.dto.MemberRegisterRequest;
 import com.backend.allreva.module.member.application.dto.RefundAccountRequest;
 import com.backend.allreva.module.member.domain.value.LoginProvider;
@@ -16,6 +17,7 @@ public final class MemberRequestFixture {
     public static Model<MemberRegisterRequest> memberRegisterRequestModel() {
         return Instancio.of(MemberRegisterRequest.class)
                 .set(field(MemberRegisterRequest.class, "loginProvider"), LoginProvider.GOOGLE)
+                .set(field(MemberRegisterRequest.class, "image"), new Image("https://example.com/profile.png"))
                 .toModel();
     }
 

--- a/src/test/java/com/backend/allreva/module/member/fixture/MemberRequestFixture.java
+++ b/src/test/java/com/backend/allreva/module/member/fixture/MemberRequestFixture.java
@@ -1,29 +1,25 @@
 package com.backend.allreva.module.member.fixture;
 
-import com.backend.allreva.common.model.Image;
+import static org.instancio.Select.field;
+
 import com.backend.allreva.module.member.application.dto.MemberRegisterRequest;
 import com.backend.allreva.module.member.application.dto.RefundAccountRequest;
 import com.backend.allreva.module.member.domain.value.LoginProvider;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.instancio.Instancio;
+import org.instancio.Model;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MemberRequestFixture {
 
-    public static MemberRegisterRequest createMemberRegisterRequest() {
-        return MemberRegisterRequest.builder()
-                .email("test@email.com")
-                .nickname("testNickname")
-                .loginProvider(LoginProvider.GOOGLE)
-                .introduce("introduce")
-                .image(new Image("https://example.com/profile.jpg"))
-                .build();
+    public static Model<MemberRegisterRequest> memberRegisterRequestModel() {
+        return Instancio.of(MemberRegisterRequest.class)
+                .set(field(MemberRegisterRequest.class, "loginProvider"), LoginProvider.GOOGLE)
+                .toModel();
     }
 
-    public static RefundAccountRequest createRefundAccountRequest() {
-        return RefundAccountRequest.builder()
-                .bank("국민은행")
-                .number("123-456-789012")
-                .build();
+    public static Model<RefundAccountRequest> refundAccountRequestModel() {
+        return Instancio.of(RefundAccountRequest.class).toModel();
     }
 }

--- a/src/test/java/com/backend/allreva/module/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/member/integration/MemberIntegrationTest.java
@@ -49,11 +49,14 @@ class MemberIntegrationTest extends IntegrationTestSupport {
 
             @Test
             void 닉네임이_user_로_시작하는_랜덤값으로_저장된다() {
+                // given
                 OAuthRegisterRequest request = new OAuthRegisterRequest(
                         "newuser@kakao.com", LoginProvider.KAKAO, "https://example.com/profile.jpg");
 
+                // when
                 Member saved = memberService.registerByOAuth(request);
 
+                // then
                 assertThat(saved.getMemberInfo().getNickname()).startsWith("user-");
                 assertThat(memberRepository.findById(saved.getId())).isPresent();
             }
@@ -65,10 +68,12 @@ class MemberIntegrationTest extends IntegrationTestSupport {
 
             @Test
             void DUPLICATE_OAUTH_MEMBER_예외가_발생한다() {
+                // given
                 memberRepository.save(MemberFixture.createTestMember(MemberFixture.EMAIL, LoginProvider.KAKAO));
                 OAuthRegisterRequest request = new OAuthRegisterRequest(
                         MemberFixture.EMAIL, LoginProvider.KAKAO, "https://example.com/profile.jpg");
 
+                // when & then
                 assertThatThrownBy(() -> memberService.registerByOAuth(request))
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", MemberErrorCode.DUPLICATE_OAUTH_MEMBER);
@@ -86,18 +91,25 @@ class MemberIntegrationTest extends IntegrationTestSupport {
 
             @Test
             void 중복된_닉네임이_있으면_true를_반환한다() {
+                // given
                 Member saved = memberRepository.save(MemberFixture.createTestMember());
                 String existingNickname = saved.getMemberInfo().getNickname();
 
+                // when
                 NicknameDuplication result = memberService.isDuplicatedNickname(existingNickname);
 
+                // then
                 assertThat(result.isDuplicated()).isTrue();
             }
 
             @Test
             void 중복된_닉네임이_없으면_false를_반환한다() {
+                // given: DB에 해당 닉네임 없음
+
+                // when
                 NicknameDuplication result = memberService.isDuplicatedNickname("nonexistentNickname");
 
+                // then
                 assertThat(result.isDuplicated()).isFalse();
             }
         }
@@ -113,12 +125,15 @@ class MemberIntegrationTest extends IntegrationTestSupport {
 
             @Test
             void 회원_정보가_성공적으로_수정된다() {
+                // given
                 Member member = memberRepository.save(MemberFixture.createTestMember());
                 MemberRegisterRequest request = Instancio.of(MemberRequestFixture.memberRegisterRequestModel())
                         .create();
 
+                // when
                 memberService.updateMemberInfo(request, member);
 
+                // then
                 assertSoftly(softly -> {
                     softly.assertThat(member.getMemberInfo().getNickname()).isEqualTo(request.nickname());
                     softly.assertThat(member.getMemberInfo().getIntroduce()).isEqualTo(request.introduce());
@@ -137,12 +152,15 @@ class MemberIntegrationTest extends IntegrationTestSupport {
 
             @Test
             void 환불_계좌가_성공적으로_등록된다() {
+                // given
                 Member member = memberRepository.save(MemberFixture.createTestMember());
                 RefundAccountRequest request = Instancio.of(MemberRequestFixture.refundAccountRequestModel())
                         .create();
 
+                // when
                 memberService.registerRefundAccount(request, member);
 
+                // then
                 assertSoftly(softly -> {
                     softly.assertThat(member.getRefundAccount().getBank()).isEqualTo(request.bank());
                     softly.assertThat(member.getRefundAccount().getNumber()).isEqualTo(request.number());
@@ -156,11 +174,14 @@ class MemberIntegrationTest extends IntegrationTestSupport {
 
             @Test
             void 환불_계좌가_성공적으로_삭제된다() {
+                // given
                 Member member = memberRepository.save(MemberFixture.createTestMember());
                 member.setRefundAccount("국민은행", "123-456-789");
 
+                // when
                 memberService.deleteRefundAccount(member);
 
+                // then
                 assertSoftly(softly -> {
                     softly.assertThat(member.getRefundAccount().getBank()).isEmpty();
                     softly.assertThat(member.getRefundAccount().getNumber()).isEmpty();

--- a/src/test/java/com/backend/allreva/module/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/member/integration/MemberIntegrationTest.java
@@ -114,7 +114,8 @@ class MemberIntegrationTest extends IntegrationTestSupport {
             @Test
             void 회원_정보가_성공적으로_수정된다() {
                 Member member = memberRepository.save(MemberFixture.createTestMember());
-                MemberRegisterRequest request = Instancio.of(MemberRequestFixture.memberRegisterRequestModel()).create();
+                MemberRegisterRequest request = Instancio.of(MemberRequestFixture.memberRegisterRequestModel())
+                        .create();
 
                 memberService.updateMemberInfo(request, member);
 
@@ -137,7 +138,8 @@ class MemberIntegrationTest extends IntegrationTestSupport {
             @Test
             void 환불_계좌가_성공적으로_등록된다() {
                 Member member = memberRepository.save(MemberFixture.createTestMember());
-                RefundAccountRequest request = Instancio.of(MemberRequestFixture.refundAccountRequestModel()).create();
+                RefundAccountRequest request = Instancio.of(MemberRequestFixture.refundAccountRequestModel())
+                        .create();
 
                 memberService.registerRefundAccount(request, member);
 

--- a/src/test/java/com/backend/allreva/module/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/member/integration/MemberIntegrationTest.java
@@ -17,6 +17,7 @@ import com.backend.allreva.module.member.exception.MemberErrorCode;
 import com.backend.allreva.module.member.fixture.MemberFixture;
 import com.backend.allreva.module.member.fixture.MemberRequestFixture;
 import com.backend.allreva.support.IntegrationTestSupport;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -113,7 +114,7 @@ class MemberIntegrationTest extends IntegrationTestSupport {
             @Test
             void 회원_정보가_성공적으로_수정된다() {
                 Member member = memberRepository.save(MemberFixture.createTestMember());
-                MemberRegisterRequest request = MemberRequestFixture.createMemberRegisterRequest();
+                MemberRegisterRequest request = Instancio.of(MemberRequestFixture.memberRegisterRequestModel()).create();
 
                 memberService.updateMemberInfo(request, member);
 
@@ -136,7 +137,7 @@ class MemberIntegrationTest extends IntegrationTestSupport {
             @Test
             void 환불_계좌가_성공적으로_등록된다() {
                 Member member = memberRepository.save(MemberFixture.createTestMember());
-                RefundAccountRequest request = MemberRequestFixture.createRefundAccountRequest();
+                RefundAccountRequest request = Instancio.of(MemberRequestFixture.refundAccountRequestModel()).create();
 
                 memberService.registerRefundAccount(request, member);
 

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/fixture/RentFixture.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/fixture/RentFixture.java
@@ -1,109 +1,54 @@
 package com.backend.allreva.module.recruitment.rent.fixture;
 
-import com.backend.allreva.common.model.Image;
+import static org.instancio.Select.field;
+
 import com.backend.allreva.module.recruitment.rent.application.dto.RentIdRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinIdRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinUpdateRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentRegisterRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentUpdateRequest;
-import com.backend.allreva.module.recruitment.rent.domain.value.BoardingType;
-import com.backend.allreva.module.recruitment.rent.domain.value.BusSize;
-import com.backend.allreva.module.recruitment.rent.domain.value.BusType;
 import com.backend.allreva.module.recruitment.rent.domain.value.RefundType;
-import com.backend.allreva.module.recruitment.rent.domain.value.Route;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.instancio.Instancio;
+import org.instancio.Model;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RentFixture {
 
-    private static final Route UP_ROUTE = Route.builder()
-            .boardingArea("서울역 앞")
-            .dropOffArea("공연장 B건물")
-            .time("10:00")
-            .build();
-    private static final Route DOWN_ROUTE = Route.builder()
-            .boardingArea("공연장 정문")
-            .dropOffArea("서울역 앞")
-            .time("22:00")
-            .build();
-
-    public static RentRegisterRequest createRentRegisterRequest(String concertCode, List<LocalDate> dates) {
-        return createRentRegisterRequest(concertCode, dates, 30);
+    public static Model<RentRegisterRequest> rentRegisterRequestModel() {
+        return Instancio.of(RentRegisterRequest.class)
+                .set(field(RentRegisterRequest.class, "endDate"), LocalDate.of(2030, 11, 30))
+                .toModel();
     }
 
-    public static RentRegisterRequest createRentRegisterRequest(
-            String concertCode, List<LocalDate> dates, int recruitmentCount) {
-        return new RentRegisterRequest(
-                concertCode,
-                "테스트 차대절",
-                "서울",
-                BoardingType.ROUND,
-                UP_ROUTE,
-                DOWN_ROUTE,
-                dates,
-                BusSize.LARGE,
-                BusType.STANDARD,
-                45,
-                50000,
-                recruitmentCount,
-                LocalDate.of(2030, 11, 30),
-                "테스트 차대절 정보",
-                new Image("https://example.com/rent.jpg"));
+    public static Model<RentUpdateRequest> rentUpdateRequestModel() {
+        return Instancio.of(RentUpdateRequest.class)
+                .set(field(RentUpdateRequest.class, "endDate"), LocalDate.of(2030, 11, 30))
+                .toModel();
     }
 
-    public static RentUpdateRequest createRentUpdateRequest(Long rentId, List<LocalDate> dates) {
-        return new RentUpdateRequest(
-                rentId,
-                "서울",
-                BoardingType.ROUND,
-                Route.builder()
-                        .boardingArea("부산역 앞")
-                        .dropOffArea("공연장 C건물")
-                        .time("09:00")
-                        .build(),
-                Route.builder()
-                        .boardingArea("공연장 정문")
-                        .dropOffArea("부산역 앞")
-                        .time("23:00")
-                        .build(),
-                dates,
-                BusSize.MEDIUM,
-                BusType.DELUXE,
-                40,
-                60000,
-                20,
-                LocalDate.of(2030, 11, 30),
-                "수정된 차대절 정보",
-                new Image("https://example.com/rent-updated.jpg"));
+    public static Model<RentJoinRequest> rentJoinRequestModel() {
+        return Instancio.of(RentJoinRequest.class)
+                .set(field(RentJoinRequest.class, "phone"), "010-1234-5678")
+                .set(field(RentJoinRequest.class, "refundType"), RefundType.REFUND)
+                .toModel();
     }
 
-    public static RentIdRequest createRentIdRequest(Long rentId) {
-        return new RentIdRequest(rentId);
+    public static Model<RentJoinUpdateRequest> rentJoinUpdateRequestModel() {
+        return Instancio.of(RentJoinUpdateRequest.class)
+                .set(field(RentJoinUpdateRequest.class, "phone"), "010-1234-5678")
+                .set(field(RentJoinUpdateRequest.class, "refundType"), RefundType.REFUND)
+                .toModel();
     }
 
-    public static RentJoinRequest createRentJoinRequest(Long rentId, LocalDate date, int passengerNum) {
-        return RentJoinRequest.builder()
-                .rentId(rentId)
-                .boardingDate(date)
-                .passengerNum(passengerNum)
-                .depositorName("홍길동")
-                .depositorTime("12:00")
-                .phone("010-1234-5678")
-                .refundType(RefundType.REFUND)
-                .refundAccount("국민은행 99999")
-                .build();
+    public static Model<RentIdRequest> rentIdRequestModel() {
+        return Instancio.of(RentIdRequest.class).toModel();
     }
 
-    public static RentJoinUpdateRequest createRentJoinUpdateRequest(final Long participantId, final LocalDate date) {
-        return new RentJoinUpdateRequest(
-                participantId, date, 3, "수정된홍길동", "15:00", "010-9999-8888", RefundType.REFUND, "신한은행 11111");
-    }
-
-    public static RentJoinIdRequest createRentJoinIdRequest(final Long participantId) {
-        return new RentJoinIdRequest(participantId);
+    public static Model<RentJoinIdRequest> rentJoinIdRequestModel() {
+        return Instancio.of(RentJoinIdRequest.class).toModel();
     }
 }

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/fixture/RentFixture.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/fixture/RentFixture.java
@@ -33,7 +33,7 @@ public final class RentFixture {
                 .set(field(RentRegisterRequest.class, "upRoute"), route)
                 .set(field(RentRegisterRequest.class, "downRoute"), route)
                 .set(field(RentRegisterRequest.class, "maxPassenger"), 45)
-                .set(field(RentRegisterRequest.class, "recruitmentCount"), 1)
+                .set(field(RentRegisterRequest.class, "recruitmentCount"), 45)
                 .set(field(RentRegisterRequest.class, "image"), new Image("https://example.com/rent.png"))
                 .toModel();
     }

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/fixture/RentFixture.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/fixture/RentFixture.java
@@ -2,13 +2,16 @@ package com.backend.allreva.module.recruitment.rent.fixture;
 
 import static org.instancio.Select.field;
 
+import com.backend.allreva.common.model.Image;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentIdRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinIdRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinUpdateRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentRegisterRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentUpdateRequest;
+import com.backend.allreva.module.recruitment.rent.domain.value.BoardingType;
 import com.backend.allreva.module.recruitment.rent.domain.value.RefundType;
+import com.backend.allreva.module.recruitment.rent.domain.value.Route;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -19,8 +22,19 @@ import org.instancio.Model;
 public final class RentFixture {
 
     public static Model<RentRegisterRequest> rentRegisterRequestModel() {
+        Route route = Route.builder()
+                .boardingArea("서울")
+                .dropOffArea("KSPO DOME")
+                .time("09:00")
+                .build();
         return Instancio.of(RentRegisterRequest.class)
                 .set(field(RentRegisterRequest.class, "endDate"), LocalDate.of(2030, 11, 30))
+                .set(field(RentRegisterRequest.class, "boardingType"), BoardingType.ROUND)
+                .set(field(RentRegisterRequest.class, "upRoute"), route)
+                .set(field(RentRegisterRequest.class, "downRoute"), route)
+                .set(field(RentRegisterRequest.class, "maxPassenger"), 45)
+                .set(field(RentRegisterRequest.class, "recruitmentCount"), 1)
+                .set(field(RentRegisterRequest.class, "image"), new Image("https://example.com/rent.png"))
                 .toModel();
     }
 
@@ -32,15 +46,23 @@ public final class RentFixture {
 
     public static Model<RentJoinRequest> rentJoinRequestModel() {
         return Instancio.of(RentJoinRequest.class)
+                .set(field(RentJoinRequest.class, "passengerNum"), 1)
+                .set(field(RentJoinRequest.class, "depositorName"), "홍길동")
+                .set(field(RentJoinRequest.class, "depositorTime"), "10:00")
                 .set(field(RentJoinRequest.class, "phone"), "010-1234-5678")
                 .set(field(RentJoinRequest.class, "refundType"), RefundType.REFUND)
+                .set(field(RentJoinRequest.class, "refundAccount"), "카카오뱅크 1234-5678")
                 .toModel();
     }
 
     public static Model<RentJoinUpdateRequest> rentJoinUpdateRequestModel() {
         return Instancio.of(RentJoinUpdateRequest.class)
+                .set(field(RentJoinUpdateRequest.class, "passengerNum"), 1)
+                .set(field(RentJoinUpdateRequest.class, "depositorName"), "홍길동")
+                .set(field(RentJoinUpdateRequest.class, "depositorTime"), "10:00")
                 .set(field(RentJoinUpdateRequest.class, "phone"), "010-1234-5678")
                 .set(field(RentJoinUpdateRequest.class, "refundType"), RefundType.REFUND)
+                .set(field(RentJoinUpdateRequest.class, "refundAccount"), "카카오뱅크 1234-5678")
                 .toModel();
     }
 

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentCommandIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentCommandIntegrationTest.java
@@ -2,6 +2,7 @@ package com.backend.allreva.module.recruitment.rent.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.instancio.Select.field;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -14,6 +15,10 @@ import com.backend.allreva.module.member.domain.Member;
 import com.backend.allreva.module.member.domain.MemberRepository;
 import com.backend.allreva.module.member.fixture.MemberFixture;
 import com.backend.allreva.module.recruitment.rent.application.RentService;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinUpdateRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentRegisterRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentUpdateRequest;
 import com.backend.allreva.module.recruitment.rent.domain.RentRepository;
 import com.backend.allreva.module.recruitment.rent.domain.participant.RentParticipantRepository;
 import com.backend.allreva.module.recruitment.rent.exception.RentErrorCode;
@@ -24,6 +29,7 @@ import com.backend.allreva.module.recruitment.rent.infra.jpa.RentParticipantJpaR
 import com.backend.allreva.support.IntegrationTestSupport;
 import java.time.LocalDate;
 import java.util.List;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -66,7 +72,7 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
     @BeforeEach
     void setUp() {
         savedMember = memberRepository.save(MemberFixture.createTestMember());
-        Concert concert = concertJpaRepository.save(ConcertFixture.createTestConcert());
+        Concert concert = concertJpaRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel()).create());
         concertCode = concert.getConcertCode();
         doNothing().when(storageUploadService).deleteImage(any());
     }
@@ -89,18 +95,22 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
         class Context_valid_request {
 
             private Long savedRentId;
+            private RentRegisterRequest savedRequest;
 
             @BeforeEach
             void setUp() {
-                savedRentId = rentService.registerRent(
-                        RentFixture.createRentRegisterRequest(concertCode, BOARDING_DATES), savedMember.getId());
+                savedRequest = Instancio.of(RentFixture.rentRegisterRequestModel())
+                        .set(field(RentRegisterRequest.class, "concertCode"), concertCode)
+                        .set(field(RentRegisterRequest.class, "rentBoardingDateRequests"), BOARDING_DATES)
+                        .create();
+                savedRentId = rentService.registerRent(savedRequest, savedMember.getId());
             }
 
             @Test
             @DisplayName("차대절이 저장된다")
             void it_saves_rent() {
                 var rent = rentRepository.findById(savedRentId).orElseThrow();
-                assertThat(rent.getTitle()).isEqualTo("테스트 차대절");
+                assertThat(rent.getTitle()).isEqualTo(savedRequest.title());
                 assertThat(rent.getMemberId()).isEqualTo(savedMember.getId());
                 assertThat(rent.getConcertCode()).isEqualTo(concertCode);
             }
@@ -111,7 +121,7 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
                 var slots = rentBoardingSlotJpaRepository.findAllByRent_Id(savedRentId);
                 assertThat(slots).hasSize(2);
                 slots.forEach(slot -> {
-                    assertThat(slot.getRecruitmentCount()).isEqualTo(30);
+                    assertThat(slot.getRecruitmentCount()).isEqualTo(savedRequest.recruitmentCount());
                     assertThat(slot.getPassengerCount()).isEqualTo(0);
                 });
             }
@@ -127,7 +137,11 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
         @BeforeEach
         void setUp() {
             savedRentId = rentService.registerRent(
-                    RentFixture.createRentRegisterRequest(concertCode, BOARDING_DATES), savedMember.getId());
+                    Instancio.of(RentFixture.rentRegisterRequestModel())
+                            .set(field(RentRegisterRequest.class, "concertCode"), concertCode)
+                            .set(field(RentRegisterRequest.class, "rentBoardingDateRequests"), BOARDING_DATES)
+                            .create(),
+                    savedMember.getId());
         }
 
         @Nested
@@ -135,19 +149,23 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
         class Context_own_rent {
 
             private static final List<LocalDate> NEW_DATES = List.of(LocalDate.of(2030, 12, 1));
+            private RentUpdateRequest updateRequest;
 
             @BeforeEach
             void setUp() {
-                rentService.updateRent(
-                        RentFixture.createRentUpdateRequest(savedRentId, NEW_DATES), savedMember.getId());
+                updateRequest = Instancio.of(RentFixture.rentUpdateRequestModel())
+                        .set(field(RentUpdateRequest.class, "rentId"), savedRentId)
+                        .set(field(RentUpdateRequest.class, "rentBoardingDateRequests"), NEW_DATES)
+                        .create();
+                rentService.updateRent(updateRequest, savedMember.getId());
             }
 
             @Test
             @DisplayName("차대절 필드가 수정된다")
             void it_updates_rent_fields() {
                 var rent = rentRepository.findById(savedRentId).orElseThrow();
-                assertThat(rent.getUpRoute().getBoardingArea()).isEqualTo("부산역 앞");
-                assertThat(rent.getUpRoute().getTime()).isEqualTo("09:00");
+                assertThat(rent.getUpRoute().getBoardingArea()).isEqualTo(updateRequest.upRoute().getBoardingArea());
+                assertThat(rent.getUpRoute().getTime()).isEqualTo(updateRequest.upRoute().getTime());
             }
 
             @Test
@@ -156,7 +174,7 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
                 var slots = rentBoardingSlotJpaRepository.findAllByRent_Id(savedRentId);
                 assertThat(slots).hasSize(1);
                 assertThat(slots.get(0).getDate()).isEqualTo(LocalDate.of(2030, 12, 1));
-                assertThat(slots.get(0).getRecruitmentCount()).isEqualTo(20);
+                assertThat(slots.get(0).getRecruitmentCount()).isEqualTo(updateRequest.recruitmentCount());
             }
         }
 
@@ -174,8 +192,11 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
-                assertThatThrownBy(() -> rentService.updateRent(
-                                RentFixture.createRentUpdateRequest(savedRentId, BOARDING_DATES), otherMember.getId()))
+                var request = Instancio.of(RentFixture.rentUpdateRequestModel())
+                        .set(field(RentUpdateRequest.class, "rentId"), savedRentId)
+                        .set(field(RentUpdateRequest.class, "rentBoardingDateRequests"), BOARDING_DATES)
+                        .create();
+                assertThatThrownBy(() -> rentService.updateRent(request, otherMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_ACCESS_DENIED.getMessage());
             }
@@ -191,7 +212,11 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
         @BeforeEach
         void setUp() {
             savedRentId = rentService.registerRent(
-                    RentFixture.createRentRegisterRequest(concertCode, BOARDING_DATES), savedMember.getId());
+                    Instancio.of(RentFixture.rentRegisterRequestModel())
+                            .set(field(RentRegisterRequest.class, "concertCode"), concertCode)
+                            .set(field(RentRegisterRequest.class, "rentBoardingDateRequests"), BOARDING_DATES)
+                            .create(),
+                    savedMember.getId());
         }
 
         @Nested
@@ -201,7 +226,11 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("차대절이 마감된다")
             void it_closes_rent() {
-                rentService.closeRent(RentFixture.createRentIdRequest(savedRentId), savedMember.getId());
+                rentService.closeRent(
+                        Instancio.of(RentFixture.rentIdRequestModel())
+                                .set(field("rentId"), savedRentId)
+                                .create(),
+                        savedMember.getId());
                 var rent = rentRepository.findById(savedRentId).orElseThrow();
                 assertThat(rent.isClosed()).isTrue();
             }
@@ -215,8 +244,10 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
-                assertThatThrownBy(() -> rentService.closeRent(
-                                RentFixture.createRentIdRequest(savedRentId), otherMember.getId()))
+                var request = Instancio.of(RentFixture.rentIdRequestModel())
+                        .set(field("rentId"), savedRentId)
+                        .create();
+                assertThatThrownBy(() -> rentService.closeRent(request, otherMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_ACCESS_DENIED.getMessage());
             }
@@ -232,7 +263,11 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
         @BeforeEach
         void setUp() {
             savedRentId = rentService.registerRent(
-                    RentFixture.createRentRegisterRequest(concertCode, BOARDING_DATES), savedMember.getId());
+                    Instancio.of(RentFixture.rentRegisterRequestModel())
+                            .set(field(RentRegisterRequest.class, "concertCode"), concertCode)
+                            .set(field(RentRegisterRequest.class, "rentBoardingDateRequests"), BOARDING_DATES)
+                            .create(),
+                    savedMember.getId());
         }
 
         @Nested
@@ -242,14 +277,22 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("차대절이 소프트 삭제된다")
             void it_soft_deletes_rent() {
-                rentService.deleteRent(RentFixture.createRentIdRequest(savedRentId), savedMember.getId());
+                rentService.deleteRent(
+                        Instancio.of(RentFixture.rentIdRequestModel())
+                                .set(field("rentId"), savedRentId)
+                                .create(),
+                        savedMember.getId());
                 assertThat(rentRepository.findById(savedRentId)).isEmpty();
             }
 
             @Test
             @DisplayName("이미지 삭제가 호출된다")
             void it_deletes_image() {
-                rentService.deleteRent(RentFixture.createRentIdRequest(savedRentId), savedMember.getId());
+                rentService.deleteRent(
+                        Instancio.of(RentFixture.rentIdRequestModel())
+                                .set(field("rentId"), savedRentId)
+                                .create(),
+                        savedMember.getId());
                 verify(storageUploadService).deleteImage(any());
             }
         }
@@ -262,8 +305,10 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
-                assertThatThrownBy(() -> rentService.deleteRent(
-                                RentFixture.createRentIdRequest(savedRentId), otherMember.getId()))
+                var request = Instancio.of(RentFixture.rentIdRequestModel())
+                        .set(field("rentId"), savedRentId)
+                        .create();
+                assertThatThrownBy(() -> rentService.deleteRent(request, otherMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_ACCESS_DENIED.getMessage());
             }
@@ -280,7 +325,12 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
         @BeforeEach
         void setUp() {
             savedRentId = rentService.registerRent(
-                    RentFixture.createRentRegisterRequest(concertCode, BOARDING_DATES), savedMember.getId());
+                    Instancio.of(RentFixture.rentRegisterRequestModel())
+                            .set(field(RentRegisterRequest.class, "concertCode"), concertCode)
+                            .set(field(RentRegisterRequest.class, "rentBoardingDateRequests"), BOARDING_DATES)
+                            .set(field(RentRegisterRequest.class, "recruitmentCount"), 30)
+                            .create(),
+                    savedMember.getId());
         }
 
         @Nested
@@ -291,7 +341,12 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @DisplayName("참여자가 저장된다")
             void it_saves_participant() {
                 Long participantId = rentService.joinRent(
-                        RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 2), savedMember.getId());
+                        Instancio.of(RentFixture.rentJoinRequestModel())
+                                .set(field(RentJoinRequest.class, "rentId"), savedRentId)
+                                .set(field(RentJoinRequest.class, "boardingDate"), TARGET_DATE)
+                                .set(field(RentJoinRequest.class, "passengerNum"), 2)
+                                .create(),
+                        savedMember.getId());
                 assertThat(participantId).isNotNull();
             }
 
@@ -299,7 +354,12 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @DisplayName("슬롯의 탑승 인원이 증가한다")
             void it_increases_passenger_count() {
                 rentService.joinRent(
-                        RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 3), savedMember.getId());
+                        Instancio.of(RentFixture.rentJoinRequestModel())
+                                .set(field(RentJoinRequest.class, "rentId"), savedRentId)
+                                .set(field(RentJoinRequest.class, "boardingDate"), TARGET_DATE)
+                                .set(field(RentJoinRequest.class, "passengerNum"), 3)
+                                .create(),
+                        savedMember.getId());
                 var slot = rentBoardingSlotJpaRepository
                         .findByRent_IdAndDate(savedRentId, TARGET_DATE)
                         .orElseThrow();
@@ -314,14 +374,24 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @BeforeEach
             void setUp() {
                 rentService.joinRent(
-                        RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 2), savedMember.getId());
+                        Instancio.of(RentFixture.rentJoinRequestModel())
+                                .set(field(RentJoinRequest.class, "rentId"), savedRentId)
+                                .set(field(RentJoinRequest.class, "boardingDate"), TARGET_DATE)
+                                .set(field(RentJoinRequest.class, "passengerNum"), 2)
+                                .create(),
+                        savedMember.getId());
             }
 
             @Test
             @DisplayName("중복 신청 예외가 발생한다")
             void it_throws_already_exists() {
                 assertThatThrownBy(() -> rentService.joinRent(
-                                RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 1), savedMember.getId()))
+                                Instancio.of(RentFixture.rentJoinRequestModel())
+                                        .set(field(RentJoinRequest.class, "rentId"), savedRentId)
+                                        .set(field(RentJoinRequest.class, "boardingDate"), TARGET_DATE)
+                                        .set(field(RentJoinRequest.class, "passengerNum"), 1)
+                                        .create(),
+                                savedMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_JOIN_ALREADY_EXISTS.getMessage());
             }
@@ -335,7 +405,12 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @DisplayName("슬롯 초과 예외가 발생한다")
             void it_throws_slot_full() {
                 assertThatThrownBy(() -> rentService.joinRent(
-                                RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 31), savedMember.getId()))
+                                Instancio.of(RentFixture.rentJoinRequestModel())
+                                        .set(field(RentJoinRequest.class, "rentId"), savedRentId)
+                                        .set(field(RentJoinRequest.class, "boardingDate"), TARGET_DATE)
+                                        .set(field(RentJoinRequest.class, "passengerNum"), 31)
+                                        .create(),
+                                savedMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.SLOT_FULL.getMessage());
             }
@@ -353,28 +428,41 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
         @BeforeEach
         void setUp() {
             savedRentId = rentService.registerRent(
-                    RentFixture.createRentRegisterRequest(concertCode, BOARDING_DATES), savedMember.getId());
+                    Instancio.of(RentFixture.rentRegisterRequestModel())
+                            .set(field(RentRegisterRequest.class, "concertCode"), concertCode)
+                            .set(field(RentRegisterRequest.class, "rentBoardingDateRequests"), BOARDING_DATES)
+                            .create(),
+                    savedMember.getId());
             participantId = rentService.joinRent(
-                    RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 2), savedMember.getId());
+                    Instancio.of(RentFixture.rentJoinRequestModel())
+                            .set(field(RentJoinRequest.class, "rentId"), savedRentId)
+                            .set(field(RentJoinRequest.class, "boardingDate"), TARGET_DATE)
+                            .set(field(RentJoinRequest.class, "passengerNum"), 2)
+                            .create(),
+                    savedMember.getId());
         }
 
         @Nested
         @DisplayName("본인 참여 내역 수정 시")
         class Context_own_participant {
 
+            private RentJoinUpdateRequest updateRequest;
+
             @BeforeEach
             void setUp() {
-                rentService.updateRentJoin(
-                        RentFixture.createRentJoinUpdateRequest(participantId, TARGET_DATE), savedMember.getId());
+                updateRequest = Instancio.of(RentFixture.rentJoinUpdateRequestModel())
+                        .set(field(RentJoinUpdateRequest.class, "rentParticipantId"), participantId)
+                        .set(field(RentJoinUpdateRequest.class, "boardingDate"), TARGET_DATE)
+                        .create();
+                rentService.updateRentJoin(updateRequest, savedMember.getId());
             }
 
             @Test
             @DisplayName("참여 정보가 수정된다")
             void it_updates_participant_fields() {
-                var participant =
-                        rentParticipantJpaRepository.findById(participantId).orElseThrow();
-                assertThat(participant.getDepositor().getDepositorName()).isEqualTo("수정된홍길동");
-                assertThat(participant.getPassengerNum()).isEqualTo(3);
+                var participant = rentParticipantJpaRepository.findById(participantId).orElseThrow();
+                assertThat(participant.getDepositor().getDepositorName()).isEqualTo(updateRequest.depositorName());
+                assertThat(participant.getPassengerNum()).isEqualTo(updateRequest.passengerNum());
             }
         }
 
@@ -392,9 +480,11 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
-                assertThatThrownBy(() -> rentService.updateRentJoin(
-                                RentFixture.createRentJoinUpdateRequest(participantId, TARGET_DATE),
-                                otherMember.getId()))
+                var request = Instancio.of(RentFixture.rentJoinUpdateRequestModel())
+                        .set(field(RentJoinUpdateRequest.class, "rentParticipantId"), participantId)
+                        .set(field(RentJoinUpdateRequest.class, "boardingDate"), TARGET_DATE)
+                        .create();
+                assertThatThrownBy(() -> rentService.updateRentJoin(request, otherMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_PARTICIPANT_ACCESS_DENIED.getMessage());
             }
@@ -412,9 +502,18 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
         @BeforeEach
         void setUp() {
             savedRentId = rentService.registerRent(
-                    RentFixture.createRentRegisterRequest(concertCode, BOARDING_DATES), savedMember.getId());
+                    Instancio.of(RentFixture.rentRegisterRequestModel())
+                            .set(field(RentRegisterRequest.class, "concertCode"), concertCode)
+                            .set(field(RentRegisterRequest.class, "rentBoardingDateRequests"), BOARDING_DATES)
+                            .create(),
+                    savedMember.getId());
             participantId = rentService.joinRent(
-                    RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 2), savedMember.getId());
+                    Instancio.of(RentFixture.rentJoinRequestModel())
+                            .set(field(RentJoinRequest.class, "rentId"), savedRentId)
+                            .set(field(RentJoinRequest.class, "boardingDate"), TARGET_DATE)
+                            .set(field(RentJoinRequest.class, "passengerNum"), 2)
+                            .create(),
+                    savedMember.getId());
         }
 
         @Nested
@@ -424,23 +523,28 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여자가 삭제된다")
             void it_deletes_participant() {
-                rentService.cancelRentJoin(RentFixture.createRentJoinIdRequest(participantId), savedMember.getId());
+                rentService.cancelRentJoin(
+                        Instancio.of(RentFixture.rentJoinIdRequestModel())
+                                .set(field("rentParticipantId"), participantId)
+                                .create(),
+                        savedMember.getId());
                 assertThat(rentParticipantJpaRepository.findById(participantId)).isEmpty();
             }
 
             @Test
             @DisplayName("탑승 슬롯의 passengerCount가 감소한다")
             void it_decreases_passenger_count() {
-                // given: joinRent에서 passengerNum=2로 신청했으므로 passengerCount=2
                 var slotBefore = rentBoardingSlotJpaRepository
                         .findByRent_IdAndDate(savedRentId, TARGET_DATE)
                         .orElseThrow();
                 assertThat(slotBefore.getPassengerCount()).isEqualTo(2);
 
-                // when
-                rentService.cancelRentJoin(RentFixture.createRentJoinIdRequest(participantId), savedMember.getId());
+                rentService.cancelRentJoin(
+                        Instancio.of(RentFixture.rentJoinIdRequestModel())
+                                .set(field("rentParticipantId"), participantId)
+                                .create(),
+                        savedMember.getId());
 
-                // then
                 var slotAfter = rentBoardingSlotJpaRepository
                         .findByRent_IdAndDate(savedRentId, TARGET_DATE)
                         .orElseThrow();
@@ -462,8 +566,10 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
-                assertThatThrownBy(() -> rentService.cancelRentJoin(
-                                RentFixture.createRentJoinIdRequest(participantId), otherMember.getId()))
+                var request = Instancio.of(RentFixture.rentJoinIdRequestModel())
+                        .set(field("rentParticipantId"), participantId)
+                        .create();
+                assertThatThrownBy(() -> rentService.cancelRentJoin(request, otherMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_PARTICIPANT_ACCESS_DENIED.getMessage());
             }

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentCommandIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentCommandIntegrationTest.java
@@ -22,7 +22,6 @@ import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinUpdat
 import com.backend.allreva.module.recruitment.rent.application.dto.RentRegisterRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentUpdateRequest;
 import com.backend.allreva.module.recruitment.rent.domain.RentRepository;
-import com.backend.allreva.module.recruitment.rent.domain.participant.RentParticipantRepository;
 import com.backend.allreva.module.recruitment.rent.exception.RentErrorCode;
 import com.backend.allreva.module.recruitment.rent.fixture.RentFixture;
 import com.backend.allreva.module.recruitment.rent.infra.jpa.RentBoardingSlotJpaRepository;
@@ -49,9 +48,6 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
     private RentRepository rentRepository;
-
-    @Autowired
-    private RentParticipantRepository rentParticipantRepository;
 
     @Autowired
     private RentJpaRepository rentJpaRepository;

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentCommandIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentCommandIntegrationTest.java
@@ -15,6 +15,8 @@ import com.backend.allreva.module.member.domain.Member;
 import com.backend.allreva.module.member.domain.MemberRepository;
 import com.backend.allreva.module.member.fixture.MemberFixture;
 import com.backend.allreva.module.recruitment.rent.application.RentService;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentIdRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinIdRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinUpdateRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentRegisterRequest;
@@ -110,7 +112,10 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("차대절이 저장된다")
             void it_saves_rent() {
+                // when
                 var rent = rentRepository.findById(savedRentId).orElseThrow();
+
+                // then
                 assertThat(rent.getTitle()).isEqualTo(savedRequest.title());
                 assertThat(rent.getMemberId()).isEqualTo(savedMember.getId());
                 assertThat(rent.getConcertCode()).isEqualTo(concertCode);
@@ -119,11 +124,14 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("탑승 날짜 슬롯이 생성된다")
             void it_creates_boarding_slots() {
+                // when
                 var slots = rentBoardingSlotJpaRepository.findAllByRent_Id(savedRentId);
+
+                // then
                 assertThat(slots).hasSize(2);
                 slots.forEach(slot -> {
                     assertThat(slot.getRecruitmentCount()).isEqualTo(savedRequest.recruitmentCount());
-                    assertThat(slot.getPassengerCount()).isEqualTo(0);
+                    assertThat(slot.getPassengerCount()).isZero();
                 });
             }
         }
@@ -164,7 +172,10 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("차대절 필드가 수정된다")
             void it_updates_rent_fields() {
+                // when
                 var rent = rentRepository.findById(savedRentId).orElseThrow();
+
+                // then
                 assertThat(rent.getUpRoute().getBoardingArea())
                         .isEqualTo(updateRequest.upRoute().getBoardingArea());
                 assertThat(rent.getUpRoute().getTime())
@@ -174,7 +185,10 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("탑승 날짜 슬롯이 교체된다")
             void it_replaces_boarding_slots() {
+                // when
                 var slots = rentBoardingSlotJpaRepository.findAllByRent_Id(savedRentId);
+
+                // then
                 assertThat(slots).hasSize(1);
                 assertThat(slots.get(0).getDate()).isEqualTo(LocalDate.of(2030, 12, 1));
                 assertThat(slots.get(0).getRecruitmentCount()).isEqualTo(updateRequest.recruitmentCount());
@@ -195,10 +209,13 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
+                // given
                 var request = Instancio.of(RentFixture.rentUpdateRequestModel())
                         .set(field(RentUpdateRequest.class, "rentId"), savedRentId)
                         .set(field(RentUpdateRequest.class, "rentBoardingDateRequests"), BOARDING_DATES)
                         .create();
+
+                // when & then
                 assertThatThrownBy(() -> rentService.updateRent(request, otherMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_ACCESS_DENIED.getMessage());
@@ -229,11 +246,14 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("차대절이 마감된다")
             void it_closes_rent() {
+                // when
                 rentService.closeRent(
                         Instancio.of(RentFixture.rentIdRequestModel())
-                                .set(field("rentId"), savedRentId)
+                                .set(field(RentIdRequest.class, "rentId"), savedRentId)
                                 .create(),
                         savedMember.getId());
+
+                // then
                 var rent = rentRepository.findById(savedRentId).orElseThrow();
                 assertThat(rent.isClosed()).isTrue();
             }
@@ -246,10 +266,13 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
+                // given
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
                 var request = Instancio.of(RentFixture.rentIdRequestModel())
-                        .set(field("rentId"), savedRentId)
+                        .set(field(RentIdRequest.class, "rentId"), savedRentId)
                         .create();
+
+                // when & then
                 assertThatThrownBy(() -> rentService.closeRent(request, otherMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_ACCESS_DENIED.getMessage());
@@ -280,22 +303,28 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("차대절이 소프트 삭제된다")
             void it_soft_deletes_rent() {
+                // when
                 rentService.deleteRent(
                         Instancio.of(RentFixture.rentIdRequestModel())
-                                .set(field("rentId"), savedRentId)
+                                .set(field(RentIdRequest.class, "rentId"), savedRentId)
                                 .create(),
                         savedMember.getId());
+
+                // then
                 assertThat(rentRepository.findById(savedRentId)).isEmpty();
             }
 
             @Test
             @DisplayName("이미지 삭제가 호출된다")
             void it_deletes_image() {
+                // when
                 rentService.deleteRent(
                         Instancio.of(RentFixture.rentIdRequestModel())
-                                .set(field("rentId"), savedRentId)
+                                .set(field(RentIdRequest.class, "rentId"), savedRentId)
                                 .create(),
                         savedMember.getId());
+
+                // then
                 verify(storageUploadService).deleteImage(any());
             }
         }
@@ -307,10 +336,13 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
+                // given
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
                 var request = Instancio.of(RentFixture.rentIdRequestModel())
-                        .set(field("rentId"), savedRentId)
+                        .set(field(RentIdRequest.class, "rentId"), savedRentId)
                         .create();
+
+                // when & then
                 assertThatThrownBy(() -> rentService.deleteRent(request, otherMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_ACCESS_DENIED.getMessage());
@@ -343,6 +375,7 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여자가 저장된다")
             void it_saves_participant() {
+                // when
                 Long participantId = rentService.joinRent(
                         Instancio.of(RentFixture.rentJoinRequestModel())
                                 .set(field(RentJoinRequest.class, "rentId"), savedRentId)
@@ -350,12 +383,15 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
                                 .set(field(RentJoinRequest.class, "passengerNum"), 2)
                                 .create(),
                         savedMember.getId());
+
+                // then
                 assertThat(participantId).isNotNull();
             }
 
             @Test
             @DisplayName("슬롯의 탑승 인원이 증가한다")
             void it_increases_passenger_count() {
+                // when
                 rentService.joinRent(
                         Instancio.of(RentFixture.rentJoinRequestModel())
                                 .set(field(RentJoinRequest.class, "rentId"), savedRentId)
@@ -363,6 +399,8 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
                                 .set(field(RentJoinRequest.class, "passengerNum"), 3)
                                 .create(),
                         savedMember.getId());
+
+                // then
                 var slot = rentBoardingSlotJpaRepository
                         .findByRent_IdAndDate(savedRentId, TARGET_DATE)
                         .orElseThrow();
@@ -388,13 +426,15 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("중복 신청 예외가 발생한다")
             void it_throws_already_exists() {
-                assertThatThrownBy(() -> rentService.joinRent(
-                                Instancio.of(RentFixture.rentJoinRequestModel())
-                                        .set(field(RentJoinRequest.class, "rentId"), savedRentId)
-                                        .set(field(RentJoinRequest.class, "boardingDate"), TARGET_DATE)
-                                        .set(field(RentJoinRequest.class, "passengerNum"), 1)
-                                        .create(),
-                                savedMember.getId()))
+                // given
+                var request = Instancio.of(RentFixture.rentJoinRequestModel())
+                        .set(field(RentJoinRequest.class, "rentId"), savedRentId)
+                        .set(field(RentJoinRequest.class, "boardingDate"), TARGET_DATE)
+                        .set(field(RentJoinRequest.class, "passengerNum"), 1)
+                        .create();
+
+                // when & then
+                assertThatThrownBy(() -> rentService.joinRent(request, savedMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_JOIN_ALREADY_EXISTS.getMessage());
             }
@@ -407,13 +447,15 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("슬롯 초과 예외가 발생한다")
             void it_throws_slot_full() {
-                assertThatThrownBy(() -> rentService.joinRent(
-                                Instancio.of(RentFixture.rentJoinRequestModel())
-                                        .set(field(RentJoinRequest.class, "rentId"), savedRentId)
-                                        .set(field(RentJoinRequest.class, "boardingDate"), TARGET_DATE)
-                                        .set(field(RentJoinRequest.class, "passengerNum"), 31)
-                                        .create(),
-                                savedMember.getId()))
+                // given
+                var request = Instancio.of(RentFixture.rentJoinRequestModel())
+                        .set(field(RentJoinRequest.class, "rentId"), savedRentId)
+                        .set(field(RentJoinRequest.class, "boardingDate"), TARGET_DATE)
+                        .set(field(RentJoinRequest.class, "passengerNum"), 31)
+                        .create();
+
+                // when & then
+                assertThatThrownBy(() -> rentService.joinRent(request, savedMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.SLOT_FULL.getMessage());
             }
@@ -463,8 +505,11 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여 정보가 수정된다")
             void it_updates_participant_fields() {
+                // when
                 var participant =
                         rentParticipantJpaRepository.findById(participantId).orElseThrow();
+
+                // then
                 assertThat(participant.getDepositor().getDepositorName()).isEqualTo(updateRequest.depositorName());
                 assertThat(participant.getPassengerNum()).isEqualTo(updateRequest.passengerNum());
             }
@@ -484,10 +529,13 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
+                // given
                 var request = Instancio.of(RentFixture.rentJoinUpdateRequestModel())
                         .set(field(RentJoinUpdateRequest.class, "rentParticipantId"), participantId)
                         .set(field(RentJoinUpdateRequest.class, "boardingDate"), TARGET_DATE)
                         .create();
+
+                // when & then
                 assertThatThrownBy(() -> rentService.updateRentJoin(request, otherMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_PARTICIPANT_ACCESS_DENIED.getMessage());
@@ -527,28 +575,34 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여자가 삭제된다")
             void it_deletes_participant() {
-                rentService.cancelRentJoin(
-                        Instancio.of(RentFixture.rentJoinIdRequestModel())
-                                .set(field("rentParticipantId"), participantId)
-                                .create(),
-                        savedMember.getId());
+                // given
+                var request = Instancio.of(RentFixture.rentJoinIdRequestModel())
+                        .set(field(RentJoinIdRequest.class, "rentParticipantId"), participantId)
+                        .create();
+
+                // when
+                rentService.cancelRentJoin(request, savedMember.getId());
+
+                // then
                 assertThat(rentParticipantJpaRepository.findById(participantId)).isEmpty();
             }
 
             @Test
             @DisplayName("탑승 슬롯의 passengerCount가 감소한다")
             void it_decreases_passenger_count() {
+                // given
                 var slotBefore = rentBoardingSlotJpaRepository
                         .findByRent_IdAndDate(savedRentId, TARGET_DATE)
                         .orElseThrow();
                 assertThat(slotBefore.getPassengerCount()).isEqualTo(2);
+                var request = Instancio.of(RentFixture.rentJoinIdRequestModel())
+                        .set(field(RentJoinIdRequest.class, "rentParticipantId"), participantId)
+                        .create();
 
-                rentService.cancelRentJoin(
-                        Instancio.of(RentFixture.rentJoinIdRequestModel())
-                                .set(field("rentParticipantId"), participantId)
-                                .create(),
-                        savedMember.getId());
+                // when
+                rentService.cancelRentJoin(request, savedMember.getId());
 
+                // then
                 var slotAfter = rentBoardingSlotJpaRepository
                         .findByRent_IdAndDate(savedRentId, TARGET_DATE)
                         .orElseThrow();
@@ -570,9 +624,12 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
+                // given
                 var request = Instancio.of(RentFixture.rentJoinIdRequestModel())
-                        .set(field("rentParticipantId"), participantId)
+                        .set(field(RentJoinIdRequest.class, "rentParticipantId"), participantId)
                         .create();
+
+                // when & then
                 assertThatThrownBy(() -> rentService.cancelRentJoin(request, otherMember.getId()))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_PARTICIPANT_ACCESS_DENIED.getMessage());

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentCommandIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentCommandIntegrationTest.java
@@ -72,7 +72,8 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
     @BeforeEach
     void setUp() {
         savedMember = memberRepository.save(MemberFixture.createTestMember());
-        Concert concert = concertJpaRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel()).create());
+        Concert concert = concertJpaRepository.save(
+                Instancio.of(ConcertFixture.inProgressConcertModel()).create());
         concertCode = concert.getConcertCode();
         doNothing().when(storageUploadService).deleteImage(any());
     }
@@ -164,8 +165,10 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @DisplayName("차대절 필드가 수정된다")
             void it_updates_rent_fields() {
                 var rent = rentRepository.findById(savedRentId).orElseThrow();
-                assertThat(rent.getUpRoute().getBoardingArea()).isEqualTo(updateRequest.upRoute().getBoardingArea());
-                assertThat(rent.getUpRoute().getTime()).isEqualTo(updateRequest.upRoute().getTime());
+                assertThat(rent.getUpRoute().getBoardingArea())
+                        .isEqualTo(updateRequest.upRoute().getBoardingArea());
+                assertThat(rent.getUpRoute().getTime())
+                        .isEqualTo(updateRequest.upRoute().getTime());
             }
 
             @Test
@@ -460,7 +463,8 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여 정보가 수정된다")
             void it_updates_participant_fields() {
-                var participant = rentParticipantJpaRepository.findById(participantId).orElseThrow();
+                var participant =
+                        rentParticipantJpaRepository.findById(participantId).orElseThrow();
                 assertThat(participant.getDepositor().getDepositorName()).isEqualTo(updateRequest.depositorName());
                 assertThat(participant.getPassengerNum()).isEqualTo(updateRequest.passengerNum());
             }

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentConcurrencyTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentConcurrencyTest.java
@@ -74,7 +74,8 @@ class RentConcurrencyTest extends IntegrationTestSupport {
                 memberRepository.save(MemberFixture.createTestMemberWithIndex(4)),
                 memberRepository.save(MemberFixture.createTestMemberWithIndex(5)));
 
-        Concert concert = concertJpaRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel()).create());
+        Concert concert = concertJpaRepository.save(
+                Instancio.of(ConcertFixture.inProgressConcertModel()).create());
         rentId = rentService.registerRent(
                 Instancio.of(RentFixture.rentRegisterRequestModel())
                         .set(field(RentRegisterRequest.class, "concertCode"), concert.getConcertCode())

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentConcurrencyTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentConcurrencyTest.java
@@ -2,6 +2,7 @@ package com.backend.allreva.module.recruitment.rent.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.instancio.Select.field;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
@@ -13,6 +14,8 @@ import com.backend.allreva.module.member.domain.Member;
 import com.backend.allreva.module.member.domain.MemberRepository;
 import com.backend.allreva.module.member.fixture.MemberFixture;
 import com.backend.allreva.module.recruitment.rent.application.RentService;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentRegisterRequest;
 import com.backend.allreva.module.recruitment.rent.fixture.RentFixture;
 import com.backend.allreva.module.recruitment.rent.infra.jpa.RentBoardingSlotJpaRepository;
 import com.backend.allreva.module.recruitment.rent.infra.jpa.RentJpaRepository;
@@ -24,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -70,10 +74,13 @@ class RentConcurrencyTest extends IntegrationTestSupport {
                 memberRepository.save(MemberFixture.createTestMemberWithIndex(4)),
                 memberRepository.save(MemberFixture.createTestMemberWithIndex(5)));
 
-        Concert concert = concertJpaRepository.save(ConcertFixture.createTestConcert());
+        Concert concert = concertJpaRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel()).create());
         rentId = rentService.registerRent(
-                RentFixture.createRentRegisterRequest(
-                        concert.getConcertCode(), List.of(BOARDING_DATE), RECRUITMENT_COUNT),
+                Instancio.of(RentFixture.rentRegisterRequestModel())
+                        .set(field(RentRegisterRequest.class, "concertCode"), concert.getConcertCode())
+                        .set(field(RentRegisterRequest.class, "rentBoardingDateRequests"), List.of(BOARDING_DATE))
+                        .set(field(RentRegisterRequest.class, "recruitmentCount"), RECRUITMENT_COUNT)
+                        .create(),
                 members.get(0).getId());
     }
 
@@ -106,7 +113,13 @@ class RentConcurrencyTest extends IntegrationTestSupport {
                 ready.countDown();
                 try {
                     start.await();
-                    rentService.joinRent(RentFixture.createRentJoinRequest(rentId, BOARDING_DATE, 1), memberId);
+                    rentService.joinRent(
+                            Instancio.of(RentFixture.rentJoinRequestModel())
+                                    .set(field(RentJoinRequest.class, "rentId"), rentId)
+                                    .set(field(RentJoinRequest.class, "boardingDate"), BOARDING_DATE)
+                                    .set(field(RentJoinRequest.class, "passengerNum"), 1)
+                                    .create(),
+                            memberId);
                     successCount.incrementAndGet();
                 } catch (CustomException e) {
                     failCount.incrementAndGet();

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentQueryIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentQueryIntegrationTest.java
@@ -2,6 +2,7 @@ package com.backend.allreva.module.recruitment.rent.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.instancio.Select.field;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
@@ -16,7 +17,10 @@ import com.backend.allreva.module.recruitment.rent.application.RentService;
 import com.backend.allreva.module.recruitment.rent.application.dto.HostedRentSummaryResponse;
 import com.backend.allreva.module.recruitment.rent.application.dto.JoinedRentResponse;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentDetailResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentIdRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentParticipantResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentRegisterRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentSummaryResponse;
 import com.backend.allreva.module.recruitment.rent.application.dto.SortType;
 import com.backend.allreva.module.recruitment.rent.exception.RentErrorCode;
@@ -29,6 +33,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -68,7 +73,7 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
     @BeforeEach
     void setUp() {
         savedMember = memberRepository.save(MemberFixture.createTestMember());
-        Concert concert = concertJpaRepository.save(ConcertFixture.createTestConcert());
+        Concert concert = concertJpaRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel()).create());
         concertCode = concert.getConcertCode();
         doNothing().when(storageUploadService).deleteImage(any());
     }
@@ -82,6 +87,21 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
         jdbcTemplate.execute("DELETE FROM member");
     }
 
+    private RentRegisterRequest buildRegisterRequest() {
+        return Instancio.of(RentFixture.rentRegisterRequestModel())
+                .set(field(RentRegisterRequest.class, "concertCode"), concertCode)
+                .set(field(RentRegisterRequest.class, "rentBoardingDateRequests"), SLOT_DATES)
+                .create();
+    }
+
+    private RentJoinRequest buildJoinRequest(final Long rentId, final LocalDate boardingDate, final int passengerNum) {
+        return Instancio.of(RentFixture.rentJoinRequestModel())
+                .set(field(RentJoinRequest.class, "rentId"), rentId)
+                .set(field(RentJoinRequest.class, "boardingDate"), boardingDate)
+                .set(field(RentJoinRequest.class, "passengerNum"), passengerNum)
+                .create();
+    }
+
     @Nested
     @DisplayName("getRentDetail 테스트")
     class Describe_getRentDetail {
@@ -90,8 +110,7 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedRentId = rentService.registerRent(
-                    RentFixture.createRentRegisterRequest(concertCode, SLOT_DATES), savedMember.getId());
+            savedRentId = rentService.registerRent(buildRegisterRequest(), savedMember.getId());
         }
 
         @Nested
@@ -130,10 +149,8 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
 
             @BeforeEach
             void setUp() {
-                // rent 15개 등록, 각 rent마다 slot 3개
                 for (int i = 0; i < 15; i++) {
-                    rentService.registerRent(
-                            RentFixture.createRentRegisterRequest(concertCode, SLOT_DATES), savedMember.getId());
+                    rentService.registerRent(buildRegisterRequest(), savedMember.getId());
                 }
             }
 
@@ -147,10 +164,13 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("마감된 차대절은 목록에 포함되지 않는다")
             void it_excludes_closed_rents() {
-                // 15개 중 1개 마감
                 List<RentSummaryResponse> all = rentService.getRentSummaries(null, SortType.LATEST, null, null, 15);
                 Long firstRentId = all.get(0).rentId();
-                rentService.closeRent(RentFixture.createRentIdRequest(firstRentId), savedMember.getId());
+                rentService.closeRent(
+                        Instancio.of(RentFixture.rentIdRequestModel())
+                                .set(field(RentIdRequest.class, "rentId"), firstRentId)
+                                .create(),
+                        savedMember.getId());
 
                 List<RentSummaryResponse> result = rentService.getRentSummaries(null, SortType.LATEST, null, null, 15);
                 assertThat(result).hasSize(14);
@@ -160,12 +180,10 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("커서 기반으로 다음 페이지를 조회할 수 있다")
             void it_paginates_with_cursor() {
-                // 1페이지: 최신순 10개
                 List<RentSummaryResponse> firstPage =
                         rentService.getRentSummaries(null, SortType.LATEST, null, null, 10);
                 assertThat(firstPage).hasSize(10);
 
-                // 2페이지: 마지막 rentId를 커서로
                 Long lastId = firstPage.get(firstPage.size() - 1).rentId();
                 List<RentSummaryResponse> secondPage =
                         rentService.getRentSummaries(null, SortType.LATEST, null, lastId, 10);
@@ -186,16 +204,12 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
 
             @BeforeEach
             void setUp() {
-                // 본인 rent 15개
                 for (int i = 0; i < 15; i++) {
-                    rentService.registerRent(
-                            RentFixture.createRentRegisterRequest(concertCode, SLOT_DATES), savedMember.getId());
+                    rentService.registerRent(buildRegisterRequest(), savedMember.getId());
                 }
-                // 타인 rent 5개
                 otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
                 for (int i = 0; i < 5; i++) {
-                    rentService.registerRent(
-                            RentFixture.createRentRegisterRequest(concertCode, SLOT_DATES), otherMember.getId());
+                    rentService.registerRent(buildRegisterRequest(), otherMember.getId());
                 }
             }
 
@@ -218,12 +232,10 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("커서 기반으로 다음 페이지를 조회할 수 있다")
             void it_paginates_with_cursor() {
-                // 1페이지
                 List<HostedRentSummaryResponse> firstPage =
                         rentService.getRentHostSummaries(savedMember.getId(), null, 10);
                 assertThat(firstPage).hasSize(10);
 
-                // 2페이지: 마지막 rentId를 커서로
                 Long lastId = firstPage.get(firstPage.size() - 1).rentId();
                 List<HostedRentSummaryResponse> secondPage =
                         rentService.getRentHostSummaries(savedMember.getId(), lastId, 10);
@@ -254,8 +266,7 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedRentId = rentService.registerRent(
-                    RentFixture.createRentRegisterRequest(concertCode, SLOT_DATES), savedMember.getId());
+            savedRentId = rentService.registerRent(buildRegisterRequest(), savedMember.getId());
         }
 
         @Nested
@@ -264,11 +275,10 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
 
             @BeforeEach
             void setUp() {
-                // member2, member3이 TARGET_DATE에 각각 참여
                 Member member2 = memberRepository.save(MemberFixture.createTestMemberWithIndex(2));
                 Member member3 = memberRepository.save(MemberFixture.createTestMemberWithIndex(3));
-                rentService.joinRent(RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 1), member2.getId());
-                rentService.joinRent(RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 1), member3.getId());
+                rentService.joinRent(buildJoinRequest(savedRentId, TARGET_DATE, 1), member2.getId());
+                rentService.joinRent(buildJoinRequest(savedRentId, TARGET_DATE, 1), member3.getId());
             }
 
             @Test
@@ -323,23 +333,22 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
     class Describe_getJoinedRentSummaries {
 
         // rent 5개 × slot 3개(12-01, 12-02, 12-03) = 15 slot
-        // savedMember: 15 slot 전체 참여 (15건)
-        // otherMember: 15 slot 전체 참여 (15건, savedMember 조회 결과에 포함되면 안 됨)
         private final List<Long> rentIds = new ArrayList<>();
         private Member otherMember;
+        private RentRegisterRequest savedRegisterRequest;
 
         @BeforeEach
         void setUp() {
             otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
+            savedRegisterRequest = buildRegisterRequest();
 
             for (int i = 0; i < 5; i++) {
-                Long rentId = rentService.registerRent(
-                        RentFixture.createRentRegisterRequest(concertCode, SLOT_DATES), savedMember.getId());
+                Long rentId = rentService.registerRent(savedRegisterRequest, savedMember.getId());
                 rentIds.add(rentId);
 
                 for (LocalDate date : SLOT_DATES) {
-                    rentService.joinRent(RentFixture.createRentJoinRequest(rentId, date, 1), savedMember.getId());
-                    rentService.joinRent(RentFixture.createRentJoinRequest(rentId, date, 1), otherMember.getId());
+                    rentService.joinRent(buildJoinRequest(rentId, date, 1), savedMember.getId());
+                    rentService.joinRent(buildJoinRequest(rentId, date, 1), otherMember.getId());
                 }
             }
         }
@@ -364,12 +373,12 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
         }
 
         @Test
-        @DisplayName("slot 정보(recruitmentCount=30, participateCount=2)가 정확히 매핑된다")
+        @DisplayName("slot 정보(recruitmentCount, participateCount=2)가 정확히 매핑된다")
         void it_maps_slot_info_correctly() {
             // savedMember + otherMember 각 1명씩 동일 slot 참여 → participateCount=2
             List<JoinedRentResponse> result = rentService.getJoinedRentSummaries(savedMember.getId(), null, 1);
             JoinedRentResponse response = result.get(0);
-            assertThat(response.recruitmentCount()).isEqualTo(30);
+            assertThat(response.recruitmentCount()).isEqualTo(savedRegisterRequest.recruitmentCount());
             assertThat(response.participateCount()).isEqualTo(2);
         }
 
@@ -408,13 +417,14 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
     class Describe_getJoinedRentDetail {
 
         private Long savedRentId;
+        private RentJoinRequest savedJoinRequest;
         private static final LocalDate TARGET_DATE = LocalDate.of(2030, 12, 1);
 
         @BeforeEach
         void setUp() {
-            savedRentId = rentService.registerRent(
-                    RentFixture.createRentRegisterRequest(concertCode, SLOT_DATES), savedMember.getId());
-            rentService.joinRent(RentFixture.createRentJoinRequest(savedRentId, TARGET_DATE, 2), savedMember.getId());
+            savedRentId = rentService.registerRent(buildRegisterRequest(), savedMember.getId());
+            savedJoinRequest = buildJoinRequest(savedRentId, TARGET_DATE, 2);
+            rentService.joinRent(savedJoinRequest, savedMember.getId());
         }
 
         @Nested
@@ -426,7 +436,7 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             void it_returns_participant_detail() {
                 RentParticipantResponse result =
                         rentService.getJoinedRentDetail(savedMember.getId(), TARGET_DATE, savedRentId);
-                assertThat(result.depositorName()).isEqualTo("홍길동");
+                assertThat(result.depositorName()).isEqualTo(savedJoinRequest.depositorName());
                 assertThat(result.passengerNum()).isEqualTo(2);
             }
         }

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentQueryIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentQueryIntegrationTest.java
@@ -121,7 +121,10 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("탑승 날짜 3개와 concert 정보가 포함된 상세가 반환된다")
             void it_returns_detail_with_concert_info() {
+                // when
                 RentDetailResponse detail = rentService.getRentDetail(savedRentId);
+
+                // then
                 assertThat(detail.boardingDates()).hasSize(3);
             }
         }
@@ -133,6 +136,7 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("NOT_FOUND 예외가 발생한다")
             void it_throws_not_found() {
+                // when & then
                 assertThatThrownBy(() -> rentService.getRentDetail(999L))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_NOT_FOUND.getMessage());
@@ -158,13 +162,17 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("pageSize=10으로 조회하면 10개가 반환된다")
             void it_includes_open_rents() {
+                // when
                 List<RentSummaryResponse> result = rentService.getRentSummaries(null, SortType.LATEST, null, null, 10);
+
+                // then
                 assertThat(result).hasSize(10);
             }
 
             @Test
             @DisplayName("마감된 차대절은 목록에 포함되지 않는다")
             void it_excludes_closed_rents() {
+                // given
                 List<RentSummaryResponse> all = rentService.getRentSummaries(null, SortType.LATEST, null, null, 15);
                 Long firstRentId = all.get(0).rentId();
                 rentService.closeRent(
@@ -173,7 +181,10 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
                                 .create(),
                         savedMember.getId());
 
+                // when
                 List<RentSummaryResponse> result = rentService.getRentSummaries(null, SortType.LATEST, null, null, 15);
+
+                // then
                 assertThat(result).hasSize(14);
                 assertThat(result).noneMatch(r -> r.rentId().equals(firstRentId));
             }
@@ -181,13 +192,17 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("커서 기반으로 다음 페이지를 조회할 수 있다")
             void it_paginates_with_cursor() {
+                // given
                 List<RentSummaryResponse> firstPage =
                         rentService.getRentSummaries(null, SortType.LATEST, null, null, 10);
                 assertThat(firstPage).hasSize(10);
 
+                // when
                 Long lastId = firstPage.get(firstPage.size() - 1).rentId();
                 List<RentSummaryResponse> secondPage =
                         rentService.getRentSummaries(null, SortType.LATEST, null, lastId, 10);
+
+                // then
                 assertThat(secondPage).hasSize(5);
             }
         }
@@ -217,29 +232,39 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("본인이 주최한 차대절만 반환되고 타인 차대절은 포함되지 않는다")
             void it_returns_only_own_rents() {
+                // when
                 List<HostedRentSummaryResponse> result =
                         rentService.getRentHostSummaries(savedMember.getId(), null, 20);
+
+                // then
                 assertThat(result).hasSize(15);
             }
 
             @Test
             @DisplayName("pageSize=10으로 조회하면 10개가 반환된다")
             void it_paginates_first_page() {
+                // when
                 List<HostedRentSummaryResponse> result =
                         rentService.getRentHostSummaries(savedMember.getId(), null, 10);
+
+                // then
                 assertThat(result).hasSize(10);
             }
 
             @Test
             @DisplayName("커서 기반으로 다음 페이지를 조회할 수 있다")
             void it_paginates_with_cursor() {
+                // given
                 List<HostedRentSummaryResponse> firstPage =
                         rentService.getRentHostSummaries(savedMember.getId(), null, 10);
                 assertThat(firstPage).hasSize(10);
 
+                // when
                 Long lastId = firstPage.get(firstPage.size() - 1).rentId();
                 List<HostedRentSummaryResponse> secondPage =
                         rentService.getRentHostSummaries(savedMember.getId(), lastId, 10);
+
+                // then
                 assertThat(secondPage).hasSize(5);
             }
         }
@@ -251,8 +276,11 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("빈 목록이 반환된다")
             void it_returns_empty_list() {
+                // when
                 List<HostedRentSummaryResponse> result =
                         rentService.getRentHostSummaries(savedMember.getId(), null, 10);
+
+                // then
                 assertThat(result).isEmpty();
             }
         }
@@ -285,17 +313,25 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("해당 날짜의 참여자 목록이 반환된다")
             void it_returns_participants_of_date() {
+                // when
                 List<RentParticipantResponse> result =
                         rentService.getRentHostDetail(savedMember.getId(), TARGET_DATE, savedRentId);
+
+                // then
                 assertThat(result).hasSize(2);
             }
 
             @Test
             @DisplayName("다른 날짜의 참여자는 포함되지 않는다")
             void it_excludes_other_date_participants() {
+                // given
                 LocalDate otherDate = LocalDate.of(2030, 12, 2);
+
+                // when
                 List<RentParticipantResponse> result =
                         rentService.getRentHostDetail(savedMember.getId(), otherDate, savedRentId);
+
+                // then
                 assertThat(result).isEmpty();
             }
         }
@@ -307,7 +343,10 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("NOT_FOUND 예외가 발생한다")
             void it_throws_not_found() {
+                // given
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
+
+                // when & then
                 assertThatThrownBy(() -> rentService.getRentHostDetail(otherMember.getId(), TARGET_DATE, savedRentId))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_NOT_FOUND.getMessage());
@@ -321,7 +360,10 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("NOT_FOUND 예외가 발생한다")
             void it_throws_not_found() {
+                // given
                 LocalDate invalidDate = LocalDate.of(2030, 12, 31);
+
+                // when & then
                 assertThatThrownBy(() -> rentService.getRentHostDetail(savedMember.getId(), invalidDate, savedRentId))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_NOT_FOUND.getMessage());
@@ -357,28 +399,37 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
         @Test
         @DisplayName("pageSize=10으로 조회하면 10개가 반환된다")
         void it_returns_first_page() {
+            // when
             List<JoinedRentResponse> result = rentService.getJoinedRentSummaries(savedMember.getId(), null, 10);
+
+            // then
             assertThat(result).hasSize(10);
         }
 
         @Test
         @DisplayName("커서 기반으로 다음 페이지를 조회할 수 있다 (1페이지=10건, 2페이지=5건)")
         void it_paginates_with_cursor() {
+            // given
             List<JoinedRentResponse> firstPage = rentService.getJoinedRentSummaries(savedMember.getId(), null, 10);
             assertThat(firstPage).hasSize(10);
 
+            // when
             Long lastParticipantId = firstPage.get(firstPage.size() - 1).rentParticipantId();
             List<JoinedRentResponse> secondPage =
                     rentService.getJoinedRentSummaries(savedMember.getId(), lastParticipantId, 10);
+
+            // then
             assertThat(secondPage).hasSize(5);
         }
 
         @Test
         @DisplayName("slot 정보(recruitmentCount, participateCount=2)가 정확히 매핑된다")
         void it_maps_slot_info_correctly() {
-            // savedMember + otherMember 각 1명씩 동일 slot 참여 → participateCount=2
+            // when
             List<JoinedRentResponse> result = rentService.getJoinedRentSummaries(savedMember.getId(), null, 1);
             JoinedRentResponse response = result.get(0);
+
+            // then (savedMember + otherMember 각 1명씩 동일 slot 참여 → participateCount=2)
             assertThat(response.recruitmentCount()).isEqualTo(savedRegisterRequest.recruitmentCount());
             assertThat(response.participateCount()).isEqualTo(2);
         }
@@ -386,7 +437,10 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
         @Test
         @DisplayName("rent별이 아닌 slot별로 반환된다 (rent 5개 × slot 3개 = 15건)")
         void it_returns_per_slot_not_per_rent() {
+            // when
             List<JoinedRentResponse> result = rentService.getJoinedRentSummaries(savedMember.getId(), null, 20);
+
+            // then
             assertThat(result).hasSize(15);
             rentIds.forEach(rentId -> {
                 long count =
@@ -398,11 +452,13 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
         @Test
         @DisplayName("타인의 참여 내역이 포함되지 않는다 (otherMember도 15건, savedMember 것과 격리)")
         void it_isolates_by_member() {
+            // when
             List<JoinedRentResponse> savedMemberResult =
                     rentService.getJoinedRentSummaries(savedMember.getId(), null, 20);
             List<JoinedRentResponse> otherMemberResult =
                     rentService.getJoinedRentSummaries(otherMember.getId(), null, 20);
 
+            // then
             assertThat(savedMemberResult).hasSize(15);
             assertThat(otherMemberResult).hasSize(15);
             assertThat(savedMemberResult)
@@ -435,8 +491,11 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여 상세가 반환된다")
             void it_returns_participant_detail() {
+                // when
                 RentParticipantResponse result =
                         rentService.getJoinedRentDetail(savedMember.getId(), TARGET_DATE, savedRentId);
+
+                // then
                 assertThat(result.depositorName()).isEqualTo(savedJoinRequest.depositorName());
                 assertThat(result.passengerNum()).isEqualTo(2);
             }
@@ -449,6 +508,7 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("NOT_FOUND 예외가 발생한다")
             void it_throws_not_found() {
+                // when & then
                 assertThatThrownBy(() -> rentService.getJoinedRentDetail(savedMember.getId(), TARGET_DATE, 999L))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_NOT_FOUND.getMessage());
@@ -462,7 +522,10 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("NOT_FOUND 예외가 발생한다")
             void it_throws_not_found_for_other_member() {
+                // given
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
+
+                // when & then
                 assertThatThrownBy(() -> rentService.getJoinedRentDetail(otherMember.getId(), TARGET_DATE, savedRentId))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(RentErrorCode.RENT_NOT_FOUND.getMessage());

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentQueryIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentQueryIntegrationTest.java
@@ -73,7 +73,8 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
     @BeforeEach
     void setUp() {
         savedMember = memberRepository.save(MemberFixture.createTestMember());
-        Concert concert = concertJpaRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel()).create());
+        Concert concert = concertJpaRepository.save(
+                Instancio.of(ConcertFixture.inProgressConcertModel()).create());
         concertCode = concert.getConcertCode();
         doNothing().when(storageUploadService).deleteImage(any());
     }

--- a/src/test/java/com/backend/allreva/module/recruitment/survey/fixture/SurveyFixture.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/survey/fixture/SurveyFixture.java
@@ -6,6 +6,7 @@ import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyR
 import com.backend.allreva.module.recruitment.survey.application.dto.OpenSurveyRequest;
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveyIdRequest;
 import com.backend.allreva.module.recruitment.survey.application.dto.UpdateSurveyRequest;
+import com.backend.allreva.module.recruitment.survey.domain.value.BoardingType;
 import com.backend.allreva.module.recruitment.survey.domain.value.Region;
 import java.time.LocalDate;
 import lombok.AccessLevel;
@@ -20,6 +21,7 @@ public final class SurveyFixture {
         return Instancio.of(OpenSurveyRequest.class)
                 .set(field(OpenSurveyRequest.class, "endDate"), LocalDate.of(2030, 11, 30))
                 .set(field(OpenSurveyRequest.class, "region"), Region.서울)
+                .set(field(OpenSurveyRequest.class, "maxPassenger"), 1)
                 .toModel();
     }
 
@@ -34,6 +36,9 @@ public final class SurveyFixture {
     }
 
     public static Model<JoinSurveyRequest> joinSurveyRequestModel() {
-        return Instancio.of(JoinSurveyRequest.class).toModel();
+        return Instancio.of(JoinSurveyRequest.class)
+                .set(field(JoinSurveyRequest.class, "boardingType"), BoardingType.ROUND)
+                .set(field(JoinSurveyRequest.class, "passengerNum"), 1)
+                .toModel();
     }
 }

--- a/src/test/java/com/backend/allreva/module/recruitment/survey/fixture/SurveyFixture.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/survey/fixture/SurveyFixture.java
@@ -1,34 +1,39 @@
 package com.backend.allreva.module.recruitment.survey.fixture;
 
+import static org.instancio.Select.field;
+
 import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyRequest;
 import com.backend.allreva.module.recruitment.survey.application.dto.OpenSurveyRequest;
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveyIdRequest;
 import com.backend.allreva.module.recruitment.survey.application.dto.UpdateSurveyRequest;
-import com.backend.allreva.module.recruitment.survey.domain.value.BoardingType;
 import com.backend.allreva.module.recruitment.survey.domain.value.Region;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.instancio.Instancio;
+import org.instancio.Model;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class SurveyFixture {
 
-    public static OpenSurveyRequest createOpenSurveyRequest(String concertCode, List<LocalDate> dates) {
-        return new OpenSurveyRequest(
-                "테스트 수요조사", concertCode, dates, Region.서울, LocalDate.of(2030, 11, 30), 45, "테스트 수요조사 정보");
+    public static Model<OpenSurveyRequest> openSurveyRequestModel() {
+        return Instancio.of(OpenSurveyRequest.class)
+                .set(field(OpenSurveyRequest.class, "endDate"), LocalDate.of(2030, 11, 30))
+                .set(field(OpenSurveyRequest.class, "region"), Region.서울)
+                .toModel();
     }
 
-    public static UpdateSurveyRequest createUpdateSurveyRequest(Long surveyId, List<LocalDate> dates) {
-        return new UpdateSurveyRequest(
-                surveyId, "수정된 수요조사", dates, Region.서울, LocalDate.of(2030, 11, 30), 30, "수정된 정보");
+    public static Model<UpdateSurveyRequest> updateSurveyRequestModel() {
+        return Instancio.of(UpdateSurveyRequest.class)
+                .set(field(UpdateSurveyRequest.class, "endDate"), LocalDate.of(2030, 11, 30))
+                .toModel();
     }
 
-    public static SurveyIdRequest createSurveyIdRequest(Long surveyId) {
-        return new SurveyIdRequest(surveyId);
+    public static Model<SurveyIdRequest> surveyIdRequestModel() {
+        return Instancio.of(SurveyIdRequest.class).toModel();
     }
 
-    public static JoinSurveyRequest createJoinSurveyRequest(Long surveyId, LocalDate boardingDate) {
-        return new JoinSurveyRequest(surveyId, boardingDate, BoardingType.ROUND, 2, false);
+    public static Model<JoinSurveyRequest> joinSurveyRequestModel() {
+        return Instancio.of(JoinSurveyRequest.class).toModel();
     }
 }

--- a/src/test/java/com/backend/allreva/module/recruitment/survey/integration/SurveyIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/survey/integration/SurveyIntegrationTest.java
@@ -2,18 +2,24 @@ package com.backend.allreva.module.recruitment.survey.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.instancio.Select.field;
 
 import com.backend.allreva.common.exception.CustomException;
 import com.backend.allreva.module.concert.concert.domain.Concert;
+import com.backend.allreva.module.concert.concert.domain.value.DateInfo;
 import com.backend.allreva.module.concert.concert.fixture.ConcertFixture;
 import com.backend.allreva.module.concert.concert.infra.jpa.ConcertJpaRepository;
 import com.backend.allreva.module.member.domain.Member;
 import com.backend.allreva.module.member.domain.MemberRepository;
 import com.backend.allreva.module.member.fixture.MemberFixture;
 import com.backend.allreva.module.recruitment.survey.application.SurveyService;
+import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyRequest;
+import com.backend.allreva.module.recruitment.survey.application.dto.OpenSurveyRequest;
 import com.backend.allreva.module.recruitment.survey.application.dto.SortType;
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveyDetailResponse;
+import com.backend.allreva.module.recruitment.survey.application.dto.SurveyIdRequest;
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveySummaryResponse;
+import com.backend.allreva.module.recruitment.survey.application.dto.UpdateSurveyRequest;
 import com.backend.allreva.module.recruitment.survey.domain.SurveyRepository;
 import com.backend.allreva.module.recruitment.survey.domain.participant.SurveyParticipantRepository;
 import com.backend.allreva.module.recruitment.survey.domain.value.Region;
@@ -24,6 +30,7 @@ import com.backend.allreva.module.recruitment.survey.infra.jpa.SurveyParticipant
 import com.backend.allreva.support.IntegrationTestSupport;
 import java.time.LocalDate;
 import java.util.List;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -63,7 +70,10 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
     @BeforeEach
     void setUp() {
         savedMember = memberRepository.save(MemberFixture.createTestMember());
-        Concert concert = concertJpaRepository.save(ConcertFixture.createTestConcert());
+        Concert concert = concertJpaRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                .set(field(DateInfo.class, "startDate"), LocalDate.of(2030, 11, 1))
+                .set(field(DateInfo.class, "endDate"), LocalDate.of(2030, 12, 31))
+                .create());
         concertCode = concert.getConcertCode();
     }
 
@@ -75,6 +85,20 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
         jdbcTemplate.execute("DELETE FROM member");
     }
 
+    private OpenSurveyRequest buildOpenRequest() {
+        return Instancio.of(SurveyFixture.openSurveyRequestModel())
+                .set(field(OpenSurveyRequest.class, "concertCode"), concertCode)
+                .set(field(OpenSurveyRequest.class, "boardingDates"), BOARDING_DATES)
+                .create();
+    }
+
+    private JoinSurveyRequest buildJoinRequest(final Long surveyId, final LocalDate boardingDate) {
+        return Instancio.of(SurveyFixture.joinSurveyRequestModel())
+                .set(field(JoinSurveyRequest.class, "surveyId"), surveyId)
+                .set(field(JoinSurveyRequest.class, "boardingDate"), boardingDate)
+                .create();
+    }
+
     @Nested
     @DisplayName("openSurvey 테스트")
     class Describe_openSurvey {
@@ -84,18 +108,19 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
         class Context_valid_request {
 
             private Long savedSurveyId;
+            private OpenSurveyRequest savedOpenRequest;
 
             @BeforeEach
             void setUp() {
-                savedSurveyId = surveyService.openSurvey(
-                        savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertCode, BOARDING_DATES));
+                savedOpenRequest = buildOpenRequest();
+                savedSurveyId = surveyService.openSurvey(savedMember.getId(), savedOpenRequest);
             }
 
             @Test
             @DisplayName("수요조사가 저장된다")
             void it_saves_survey() {
                 var survey = surveyRepository.findById(savedSurveyId).orElseThrow();
-                assertThat(survey.getTitle()).isEqualTo("테스트 수요조사");
+                assertThat(survey.getTitle()).isEqualTo(savedOpenRequest.title());
             }
 
             @Test
@@ -116,8 +141,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedSurveyId = surveyService.openSurvey(
-                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertCode, BOARDING_DATES));
+            savedSurveyId = surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Nested
@@ -127,10 +151,13 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("수요조사가 수정된다")
             void it_updates_survey() {
-                surveyService.updateSurvey(
-                        savedMember.getId(), SurveyFixture.createUpdateSurveyRequest(savedSurveyId, BOARDING_DATES));
+                UpdateSurveyRequest updateRequest = Instancio.of(SurveyFixture.updateSurveyRequestModel())
+                        .set(field(UpdateSurveyRequest.class, "surveyId"), savedSurveyId)
+                        .set(field(UpdateSurveyRequest.class, "boardingDates"), BOARDING_DATES)
+                        .create();
+                surveyService.updateSurvey(savedMember.getId(), updateRequest);
                 var survey = surveyRepository.findById(savedSurveyId).orElseThrow();
-                assertThat(survey.getTitle()).isEqualTo("수정된 수요조사");
+                assertThat(survey.getTitle()).isEqualTo(updateRequest.title());
             }
         }
 
@@ -142,9 +169,11 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
-                assertThatThrownBy(() -> surveyService.updateSurvey(
-                                otherMember.getId(),
-                                SurveyFixture.createUpdateSurveyRequest(savedSurveyId, BOARDING_DATES)))
+                UpdateSurveyRequest updateRequest = Instancio.of(SurveyFixture.updateSurveyRequestModel())
+                        .set(field(UpdateSurveyRequest.class, "surveyId"), savedSurveyId)
+                        .set(field(UpdateSurveyRequest.class, "boardingDates"), BOARDING_DATES)
+                        .create();
+                assertThatThrownBy(() -> surveyService.updateSurvey(otherMember.getId(), updateRequest))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(SurveyErrorCode.SURVEY_NOT_WRITER.getMessage());
             }
@@ -159,8 +188,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedSurveyId = surveyService.openSurvey(
-                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertCode, BOARDING_DATES));
+            savedSurveyId = surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Nested
@@ -170,7 +198,10 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("수요조사가 소프트 삭제된다")
             void it_soft_deletes_survey() {
-                surveyService.removeSurvey(savedMember.getId(), SurveyFixture.createSurveyIdRequest(savedSurveyId));
+                surveyService.removeSurvey(savedMember.getId(),
+                        Instancio.of(SurveyFixture.surveyIdRequestModel())
+                                .set(field(SurveyIdRequest.class, "surveyId"), savedSurveyId)
+                                .create());
                 assertThat(surveyRepository.findById(savedSurveyId)).isEmpty();
             }
         }
@@ -183,8 +214,10 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
-                assertThatThrownBy(() -> surveyService.removeSurvey(
-                                otherMember.getId(), SurveyFixture.createSurveyIdRequest(savedSurveyId)))
+                SurveyIdRequest idRequest = Instancio.of(SurveyFixture.surveyIdRequestModel())
+                        .set(field(SurveyIdRequest.class, "surveyId"), savedSurveyId)
+                        .create();
+                assertThatThrownBy(() -> surveyService.removeSurvey(otherMember.getId(), idRequest))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(SurveyErrorCode.SURVEY_NOT_WRITER.getMessage());
             }
@@ -200,8 +233,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedSurveyId = surveyService.openSurvey(
-                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertCode, BOARDING_DATES));
+            savedSurveyId = surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Nested
@@ -212,7 +244,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @DisplayName("참여자가 저장된다")
             void it_saves_participant() {
                 Long participantId = surveyService.joinSurvey(
-                        savedMember.getId(), SurveyFixture.createJoinSurveyRequest(savedSurveyId, TARGET_DATE));
+                        savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
                 assertThat(participantId).isNotNull();
             }
         }
@@ -223,15 +255,14 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
             @BeforeEach
             void setUp() {
-                surveyService.joinSurvey(
-                        savedMember.getId(), SurveyFixture.createJoinSurveyRequest(savedSurveyId, TARGET_DATE));
+                surveyService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
             }
 
             @Test
             @DisplayName("중복 참여 예외가 발생한다")
             void it_throws_already_exists() {
                 assertThatThrownBy(() -> surveyService.joinSurvey(
-                                savedMember.getId(), SurveyFixture.createJoinSurveyRequest(savedSurveyId, TARGET_DATE)))
+                                savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE)))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(SurveyErrorCode.SURVEY_JOIN_ALREADY_EXISTS.getMessage());
             }
@@ -247,8 +278,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedSurveyId = surveyService.openSurvey(
-                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertCode, BOARDING_DATES));
+            savedSurveyId = surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Nested
@@ -259,7 +289,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @DisplayName("참여자가 삭제된다")
             void it_deletes_participant() {
                 Long participantId = surveyService.joinSurvey(
-                        savedMember.getId(), SurveyFixture.createJoinSurveyRequest(savedSurveyId, TARGET_DATE));
+                        savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
                 surveyService.cancelJoin(savedMember.getId(), participantId);
                 assertThat(surveyParticipantRepository.findById(participantId)).isEmpty();
             }
@@ -273,7 +303,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
                 Long participantId = surveyService.joinSurvey(
-                        savedMember.getId(), SurveyFixture.createJoinSurveyRequest(savedSurveyId, TARGET_DATE));
+                        savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
                 assertThatThrownBy(() -> surveyService.cancelJoin(otherMember.getId(), participantId))
                         .isInstanceOf(CustomException.class)
@@ -290,8 +320,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedSurveyId = surveyService.openSurvey(
-                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertCode, BOARDING_DATES));
+            savedSurveyId = surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Nested
@@ -326,8 +355,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            surveyService.openSurvey(
-                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertCode, BOARDING_DATES));
+            surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Test
@@ -356,8 +384,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            surveyService.openSurvey(
-                    savedMember.getId(), SurveyFixture.createOpenSurveyRequest(concertCode, BOARDING_DATES));
+            surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Test

--- a/src/test/java/com/backend/allreva/module/recruitment/survey/integration/SurveyIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/survey/integration/SurveyIntegrationTest.java
@@ -119,14 +119,20 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("수요조사가 저장된다")
             void it_saves_survey() {
+                // when
                 var survey = surveyRepository.findById(savedSurveyId).orElseThrow();
+
+                // then
                 assertThat(survey.getTitle()).isEqualTo(savedOpenRequest.title());
             }
 
             @Test
             @DisplayName("탑승 날짜가 JSONB로 저장된다")
             void it_saves_boarding_dates_as_jsonb() {
+                // when
                 var survey = surveyRepository.findById(savedSurveyId).orElseThrow();
+
+                // then
                 assertThat(survey.getBoardingDates()).hasSize(2);
                 assertThat(survey.getBoardingDates()).containsAll(BOARDING_DATES);
             }
@@ -151,11 +157,16 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("수요조사가 수정된다")
             void it_updates_survey() {
+                // given
                 UpdateSurveyRequest updateRequest = Instancio.of(SurveyFixture.updateSurveyRequestModel())
                         .set(field(UpdateSurveyRequest.class, "surveyId"), savedSurveyId)
                         .set(field(UpdateSurveyRequest.class, "boardingDates"), BOARDING_DATES)
                         .create();
+
+                // when
                 surveyService.updateSurvey(savedMember.getId(), updateRequest);
+
+                // then
                 var survey = surveyRepository.findById(savedSurveyId).orElseThrow();
                 assertThat(survey.getTitle()).isEqualTo(updateRequest.title());
             }
@@ -168,11 +179,14 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
+                // given
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
                 UpdateSurveyRequest updateRequest = Instancio.of(SurveyFixture.updateSurveyRequestModel())
                         .set(field(UpdateSurveyRequest.class, "surveyId"), savedSurveyId)
                         .set(field(UpdateSurveyRequest.class, "boardingDates"), BOARDING_DATES)
                         .create();
+
+                // when & then
                 assertThatThrownBy(() -> surveyService.updateSurvey(otherMember.getId(), updateRequest))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(SurveyErrorCode.SURVEY_NOT_WRITER.getMessage());
@@ -198,11 +212,15 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("수요조사가 소프트 삭제된다")
             void it_soft_deletes_survey() {
-                surveyService.removeSurvey(
-                        savedMember.getId(),
-                        Instancio.of(SurveyFixture.surveyIdRequestModel())
-                                .set(field(SurveyIdRequest.class, "surveyId"), savedSurveyId)
-                                .create());
+                // given
+                SurveyIdRequest idRequest = Instancio.of(SurveyFixture.surveyIdRequestModel())
+                        .set(field(SurveyIdRequest.class, "surveyId"), savedSurveyId)
+                        .create();
+
+                // when
+                surveyService.removeSurvey(savedMember.getId(), idRequest);
+
+                // then
                 assertThat(surveyRepository.findById(savedSurveyId)).isEmpty();
             }
         }
@@ -214,10 +232,13 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
+                // given
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
                 SurveyIdRequest idRequest = Instancio.of(SurveyFixture.surveyIdRequestModel())
                         .set(field(SurveyIdRequest.class, "surveyId"), savedSurveyId)
                         .create();
+
+                // when & then
                 assertThatThrownBy(() -> surveyService.removeSurvey(otherMember.getId(), idRequest))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(SurveyErrorCode.SURVEY_NOT_WRITER.getMessage());
@@ -244,8 +265,11 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여자가 저장된다")
             void it_saves_participant() {
+                // when
                 Long participantId =
                         surveyService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
+
+                // then
                 assertThat(participantId).isNotNull();
             }
         }
@@ -262,6 +286,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("중복 참여 예외가 발생한다")
             void it_throws_already_exists() {
+                // when & then
                 assertThatThrownBy(() -> surveyService.joinSurvey(
                                 savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE)))
                         .isInstanceOf(CustomException.class)
@@ -289,9 +314,14 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여자가 삭제된다")
             void it_deletes_participant() {
+                // given
                 Long participantId =
                         surveyService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
+
+                // when
                 surveyService.cancelJoin(savedMember.getId(), participantId);
+
+                // then
                 assertThat(surveyParticipantRepository.findById(participantId)).isEmpty();
             }
         }
@@ -303,9 +333,12 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
+                // given
                 Long participantId =
                         surveyService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
+
+                // when & then
                 assertThatThrownBy(() -> surveyService.cancelJoin(otherMember.getId(), participantId))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(SurveyErrorCode.SURVEY_JOIN_ACCESS_DENIED.getMessage());
@@ -331,7 +364,10 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("상세 정보가 반환된다")
             void it_returns_detail() {
+                // when
                 SurveyDetailResponse detail = surveyService.findSurveyDetail(savedSurveyId);
+
+                // then
                 assertThat(detail).isNotNull();
             }
         }
@@ -343,6 +379,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("NOT_FOUND 예외가 발생한다")
             void it_throws_not_found() {
+                // when & then
                 assertThatThrownBy(() -> surveyService.findSurveyDetail(999L))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(SurveyErrorCode.SURVEY_NOT_FOUND.getMessage());
@@ -362,19 +399,24 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
         @Test
         @DisplayName("지역 필터링이 동작한다")
         void it_filters_by_region() {
+            // when
             List<SurveySummaryResponse> seoulResults =
                     surveyService.findSurveyList(Region.서울, SortType.LATEST, null, null, 10);
-            assertThat(seoulResults).isNotEmpty();
-
             List<SurveySummaryResponse> busanResults =
                     surveyService.findSurveyList(Region.부산, SortType.LATEST, null, null, 10);
+
+            // then
+            assertThat(seoulResults).isNotEmpty();
             assertThat(busanResults).isEmpty();
         }
 
         @Test
         @DisplayName("최신순 정렬로 목록이 반환된다")
         void it_sorts_by_latest() {
+            // when
             List<SurveySummaryResponse> results = surveyService.findSurveyList(null, SortType.LATEST, null, null, 10);
+
+            // then
             assertThat(results).isNotEmpty();
         }
     }
@@ -391,11 +433,15 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
         @Test
         @DisplayName("개설자의 수요조사 목록이 반환된다")
         void it_returns_own_surveys() {
-            var ownSurveys = surveyService.findCreatedSurveyList(savedMember.getId(), null, null, 10);
-            assertThat(ownSurveys).isNotEmpty();
-
+            // given
             Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
+
+            // when
+            var ownSurveys = surveyService.findCreatedSurveyList(savedMember.getId(), null, null, 10);
             var otherSurveys = surveyService.findCreatedSurveyList(otherMember.getId(), null, null, 10);
+
+            // then
+            assertThat(ownSurveys).isNotEmpty();
             assertThat(otherSurveys).isEmpty();
         }
     }

--- a/src/test/java/com/backend/allreva/module/recruitment/survey/integration/SurveyIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/survey/integration/SurveyIntegrationTest.java
@@ -198,7 +198,8 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("수요조사가 소프트 삭제된다")
             void it_soft_deletes_survey() {
-                surveyService.removeSurvey(savedMember.getId(),
+                surveyService.removeSurvey(
+                        savedMember.getId(),
                         Instancio.of(SurveyFixture.surveyIdRequestModel())
                                 .set(field(SurveyIdRequest.class, "surveyId"), savedSurveyId)
                                 .create());
@@ -243,8 +244,8 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여자가 저장된다")
             void it_saves_participant() {
-                Long participantId = surveyService.joinSurvey(
-                        savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
+                Long participantId =
+                        surveyService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
                 assertThat(participantId).isNotNull();
             }
         }
@@ -288,8 +289,8 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여자가 삭제된다")
             void it_deletes_participant() {
-                Long participantId = surveyService.joinSurvey(
-                        savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
+                Long participantId =
+                        surveyService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
                 surveyService.cancelJoin(savedMember.getId(), participantId);
                 assertThat(surveyParticipantRepository.findById(participantId)).isEmpty();
             }
@@ -302,8 +303,8 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
-                Long participantId = surveyService.joinSurvey(
-                        savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
+                Long participantId =
+                        surveyService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
                 assertThatThrownBy(() -> surveyService.cancelJoin(otherMember.getId(), participantId))
                         .isInstanceOf(CustomException.class)

--- a/src/test/java/com/backend/allreva/module/search/integration/ConcertSearchServiceTest.java
+++ b/src/test/java/com/backend/allreva/module/search/integration/ConcertSearchServiceTest.java
@@ -1,15 +1,18 @@
 package com.backend.allreva.module.search.integration;
 
-import static com.backend.allreva.module.concert.concert.fixture.ConcertFixture.createConcertWithCodes;
-import static com.backend.allreva.module.concert.concert.fixture.ConcertFixture.createConcertWithHallCode;
-import static com.backend.allreva.module.concert.place.fixture.ConcertHallFixture.createConcertHall;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.instancio.Select.field;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.backend.allreva.common.exception.CustomException;
+import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
+import com.backend.allreva.module.concert.concert.domain.value.ConcertInfo;
+import com.backend.allreva.module.concert.concert.fixture.ConcertFixture;
+import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
+import com.backend.allreva.module.concert.place.fixture.ConcertHallFixture;
 import com.backend.allreva.module.search.application.ConcertSearchService;
 import com.backend.allreva.module.search.application.dto.ConcertMainResponse;
 import com.backend.allreva.module.search.application.dto.ConcertSearchListResponse;
@@ -18,6 +21,7 @@ import com.backend.allreva.module.search.application.dto.SortDirection;
 import com.backend.allreva.support.IntegrationTestSupport;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -55,11 +59,17 @@ class ConcertSearchServiceTest extends IntegrationTestSupport {
             @Test
             @DisplayName("검색 결과가 반환된다")
             void 검색_결과가_반환된다() {
-                // given - ConcertFixture의 hallCode "123"과 일치하는 hall 저장
+                // given
                 String hallCode = "FCMOCK01-1";
                 String concertCode = "PFMOCK001";
-                concertHallRepository.save(createConcertHall(hallCode));
-                concertRepository.save(createConcertWithHallCode(concertCode)); // title: "Sample Concert"
+                concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
+                        .set(field(ConcertHall.class, "hallCode"), hallCode)
+                        .create());
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), concertCode)
+                        .set(field(Concert.class, "hallCode"), hallCode)
+                        .set(field(ConcertInfo.class, "title"), "Sample Concert")
+                        .create());
 
                 // when
                 List<ConcertThumbnail> result = concertSearchService.searchConcertThumbnails("Sample");
@@ -84,9 +94,15 @@ class ConcertSearchServiceTest extends IntegrationTestSupport {
             void cursorId로_다음_페이지를_조회할_수_있다() {
                 // given
                 String hallCode = "FCMOCK01-1";
-                concertHallRepository.save(createConcertHall(hallCode));
+                concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
+                        .set(field(ConcertHall.class, "hallCode"), hallCode)
+                        .create());
                 for (int i = 0; i < 3; i++) {
-                    concertRepository.save(createConcertWithCodes("PFMOCK00" + i, hallCode));
+                    concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                            .set(field(Concert.class, "concertCode"), "PFMOCK00" + i)
+                            .set(field(Concert.class, "hallCode"), hallCode)
+                            .set(field(ConcertInfo.class, "title"), "Sample Concert")
+                            .create());
                 }
 
                 // when
@@ -122,9 +138,15 @@ class ConcertSearchServiceTest extends IntegrationTestSupport {
         void 날짜_정렬로_메인_콘서트를_조회한다() {
             // given
             String hallCode = "FCMOCK01-1";
-            concertHallRepository.save(createConcertHall(hallCode));
+            concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
+                    .set(field(ConcertHall.class, "hallCode"), hallCode)
+                    .create());
             for (int i = 0; i < 5; i++) {
-                concertRepository.save(createConcertWithCodes("PFMOCK00" + i, hallCode));
+                concertRepository.save(Instancio.of(ConcertFixture.inProgressConcertModel())
+                        .set(field(Concert.class, "concertCode"), "PFMOCK00" + i)
+                        .set(field(Concert.class, "hallCode"), hallCode)
+                        .set(field(ConcertInfo.class, "title"), "Sample Concert")
+                        .create());
             }
 
             // when

--- a/src/test/java/com/backend/allreva/module/search/integration/PlaceSearchServiceTest.java
+++ b/src/test/java/com/backend/allreva/module/search/integration/PlaceSearchServiceTest.java
@@ -1,15 +1,18 @@
 package com.backend.allreva.module.search.integration;
 
-import static com.backend.allreva.module.concert.place.fixture.ConcertHallFixture.createConcertHall;
-import static com.backend.allreva.module.concert.place.fixture.ConcertHallFixture.createTestConcertHall;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.instancio.Select.field;
 
 import com.backend.allreva.module.concert.place.application.dto.ConcertHallMainResponse;
+import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
+import com.backend.allreva.module.concert.place.domain.value.Location;
+import com.backend.allreva.module.concert.place.fixture.ConcertHallFixture;
 import com.backend.allreva.module.search.application.PlaceSearchService;
 import com.backend.allreva.support.IntegrationTestSupport;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -52,7 +55,10 @@ class PlaceSearchServiceTest extends IntegrationTestSupport {
             @DisplayName("해당 지역의 공연장이 반환된다")
             void 해당_지역의_공연장이_반환된다() {
                 // given
-                concertHallRepository.save(createTestConcertHall());
+                concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
+                        .set(field(Location.class, "address"), "서울특별시 종로구")
+                        .set(field(ConcertHall.class, "seatScale"), 5000)
+                        .create());
                 String address = "서울";
                 int seatScale = 0;
                 int size = 10;
@@ -76,7 +82,10 @@ class PlaceSearchServiceTest extends IntegrationTestSupport {
             @DisplayName("지정한 좌석 규모 이상의 공연장만 반환된다")
             void 지정한_좌석_규모_이상의_공연장만_반환된다() {
                 // given
-                concertHallRepository.save(createTestConcertHall());
+                concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
+                        .set(field(Location.class, "address"), "서울특별시 종로구")
+                        .set(field(ConcertHall.class, "seatScale"), 5000)
+                        .create());
                 String address = "";
                 int seatScale = 2000;
                 int size = 10;
@@ -104,7 +113,9 @@ class PlaceSearchServiceTest extends IntegrationTestSupport {
             void nextCursorId를_사용하여_다음_페이지를_조회할_수_있다() {
                 // given - 각각 다른 ID로 5개 저장
                 for (int i = 1; i <= 5; i++) {
-                    concertHallRepository.save(createConcertHall(String.format("hall-%03d", i)));
+                    concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
+                            .set(field(ConcertHall.class, "hallCode"), String.format("hall-%03d", i))
+                            .create());
                 }
                 String address = "";
                 int seatScale = 0;


### PR DESCRIPTION
## 작업 내용

Object Mother 패턴 fixture는 엔티티 필드 변경 시 모든 메서드를 수정해야 하는 문제가 있음.
Instancio의 `toModel()` 패턴으로 전환해 "관심 있는 필드만 명시, 나머지는 랜덤" 방식으로 개선.

## 구현

- `instancio-junit:5.5.1` 의존성 추가
- fixture 6개 → `*Model()` 반환 방식으로 재작성 (기존 정적 생성 메서드 제거)
  - `ConcertFixture`, `ConcertHallFixture`, `MemberFixture`, `MemberRequestFixture`, `RentFixture`, `SurveyFixture`
- 테스트 11개 → `Instancio.of(fixture.model()).set(field(...), value).create()` 패턴 적용
- JPA 엔티티 관련 주의 사항 처리:
  - `@GeneratedValue(IDENTITY)` 엔티티: `ignore(field(Member.class, "id"))` 로 null 강제
  - `@SQLRestriction("deleted_at IS NULL")` 엔티티: `ignore(field(BaseEntity.class, "deletedAt"))` 로 soft-delete 필터 충돌 방지

## 테스트

전체 통합 테스트 통과 확인 (`./gradlew test`)

Closes #49