### PR TITLE
[#53] Swagger 인터페이스 파라미터 제약 조건 정리 및 역할 표시 추가

### DIFF
--- a/src/main/java/com/backend/allreva/common/config/SwaggerConfig.java
+++ b/src/main/java/com/backend/allreva/common/config/SwaggerConfig.java
@@ -3,7 +3,6 @@ package com.backend.allreva.common.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import java.text.MessageFormat;
@@ -25,16 +24,13 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI customOpenAPI() {
-        SecurityRequirement developerRequirement = new SecurityRequirement().addList("USER");
-
         Server server1 = new Server();
         server1.setUrl(MessageFormat.format("{0}://{1}", protocol, domain));
 
         return new OpenAPI()
                 .info(new Info().title("Allreva"))
                 .servers(List.of(server1))
-                .components(new Components().addSecuritySchemes("USER", createSecurityScheme()))
-                .addSecurityItem(developerRequirement);
+                .components(new Components().addSecuritySchemes("USER", createSecurityScheme()));
     }
 
     private SecurityScheme createSecurityScheme() {

--- a/src/main/java/com/backend/allreva/common/storage/presigned/PresignedUrlController.java
+++ b/src/main/java/com/backend/allreva/common/storage/presigned/PresignedUrlController.java
@@ -4,9 +4,7 @@ import com.backend.allreva.common.storage.presigned.dto.PresignedUrlRequest;
 import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.auth.security.AuthMember;
 import com.backend.allreva.module.member.domain.Member;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,59 +18,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/storage/presigned-urls")
 @RequiredArgsConstructor
-@Tag(name = "Storage - Presigned URL", description = "S3 Presigned URL 생성 API")
-public class PresignedUrlController {
+public class PresignedUrlController implements PresignedUrlControllerSwagger {
 
     private final PresignedUrlService presignedUrlService;
 
-    /**
-     * 파일 업로드용 Presigned URL 생성
-     *
-     * @param request 파일명과 파일 타입 정보
-     * @param member 인증된 회원 정보 (선택적)
-     * @return 10분간 유효한 Presigned PUT URL
-     */
+    @Override
     @PostMapping
-    @Operation(
-            summary = "파일 업로드 URL 생성",
-            description = "클라이언트가 S3에 직접 파일을 업로드할 수 있는 임시 URL을 생성합니다. "
-                    + "생성된 URL은 10분간 유효하며, PUT 메서드로 파일을 업로드할 수 있습니다.\n\n"
-                    + "파일 타입별 저장 경로:\n"
-                    + "- PROFILE: [닉네임]/PROFILE/UUID_파일명\n"
-                    + "- CHAT: [닉네임]/CHAT/UUID_파일명\n"
-                    + "- REVIEW: [닉네임]/REVIEW/UUID_파일명\n"
-                    + "- SURVEY: [닉네임]/SURVEY/UUID_파일명\n"
-                    + "- RENT: [닉네임]/RENT/UUID_파일명")
     public Response<String> generateUploadUrl(
             @Valid @RequestBody PresignedUrlRequest request, @Parameter(hidden = true) @AuthMember Member member) {
-
         log.info("Generating upload presigned URL for file: {} (type: {})", request.fileName(), request.fileType());
-
-        String presignedUrl = presignedUrlService.generateUploadUrl(request, member);
-
-        return Response.onSuccess(presignedUrl);
+        return Response.onSuccess(presignedUrlService.generateUploadUrl(request, member));
     }
 
-    /**
-     * 파일 삭제용 Presigned URL 생성
-     *
-     * @param fileUrl 삭제할 파일의 전체 S3 URL
-     * @return 10분간 유효한 Presigned DELETE URL
-     */
+    @Override
     @PostMapping("/delete")
-    @Operation(
-            summary = "파일 삭제 URL 생성",
-            description =
-                    "클라이언트가 S3에서 직접 파일을 삭제할 수 있는 임시 URL을 생성합니다. " + "생성된 URL은 10분간 유효하며, DELETE 메서드로 파일을 삭제할 수 있습니다.")
     public Response<String> generateDeleteUrl(
-            @Parameter(description = "삭제할 파일의 전체 S3 URL", example = "https://bucket.s3.amazonaws.com/path/file.jpg")
-                    @RequestParam
-                    String fileUrl) {
-
+            @Parameter(description = "삭제할 파일의 전체 S3 URL") @RequestParam String fileUrl) {
         log.info("Generating delete presigned URL for file: {}", fileUrl);
-
-        String presignedUrl = presignedUrlService.generateDeleteUrl(fileUrl);
-
-        return Response.onSuccess(presignedUrl);
+        return Response.onSuccess(presignedUrlService.generateDeleteUrl(fileUrl));
     }
 }

--- a/src/main/java/com/backend/allreva/common/storage/presigned/PresignedUrlControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/common/storage/presigned/PresignedUrlControllerSwagger.java
@@ -1,0 +1,20 @@
+package com.backend.allreva.common.storage.presigned;
+
+import com.backend.allreva.common.storage.presigned.dto.PresignedUrlRequest;
+import com.backend.allreva.common.web.response.Response;
+import com.backend.allreva.module.member.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "스토리지 API", description = "S3 Presigned URL 관련 API")
+public interface PresignedUrlControllerSwagger {
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "파일 업로드 URL 생성", description = "**[회원]** S3 직접 업로드용 Presigned PUT URL 생성. 10분간 유효")
+    Response<String> generateUploadUrl(PresignedUrlRequest request, Member member);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "파일 삭제 URL 생성", description = "**[회원]** S3 직접 삭제용 Presigned DELETE URL 생성. 10분간 유효")
+    Response<String> generateDeleteUrl(String fileUrl);
+}

--- a/src/main/java/com/backend/allreva/module/auth/presentation/AuthControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/auth/presentation/AuthControllerSwagger.java
@@ -7,23 +7,21 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-@Tag(name = "회원 인증 및 인가 API", description = "인증 및 인가를 처리합니다")
+@Tag(name = "인증 API", description = "인증 관련 API")
 public interface AuthControllerSwagger {
 
-    @Operation(
-            summary = "kakao oauth2 인가코드 요청",
-            description = "인가코드를 바탕으로 사용자를 인증합니다.\n" + "먼저 카카오 로그인을 한 후에 authorization code를 받아서 이를 파라미터로 넘겨야 합니다.")
+    @Operation(summary = "카카오 로그인", description = "인가코드로 카카오 OAuth2 로그인")
     Response<UserInfoResponse> authKakaoLogin(
             String authorizationCode, HttpServletRequest request, HttpServletResponse response);
 
-    @Operation(summary = "access token 재발급 요청", description = "refresh token을 이용하여 access token을 재발급합니다.")
+    @Operation(summary = "토큰 재발급", description = "refresh token으로 access token 재발급")
     Response<Void> reissueToken(String refreshToken, HttpServletRequest request, HttpServletResponse response);
 
-    @Operation(summary = "로그인 체크", description = "refresh token을 이용하여 access token을 재발급합니다.")
+    @Operation(summary = "로그인 체크", description = "refresh token으로 로그인 상태 확인 및 토큰 재발급")
     Response<UserInfoResponse> loginCheck(
             String refreshToken, HttpServletRequest request, HttpServletResponse response);
 
-    @Operation(summary = "로그아웃", description = "refresh token을 삭제함으로써 로그아웃합니다.")
+    @Operation(summary = "로그아웃", description = "refresh token 삭제")
     Response<Void> logout(
             final String refreshToken, final HttpServletRequest request, final HttpServletResponse response);
 }

--- a/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertController.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertController.java
@@ -4,8 +4,6 @@ import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.concert.concert.application.ConcertService;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
@@ -25,17 +23,16 @@ public class ConcertController implements ConcertControllerSwagger {
 
     @Override
     @GetMapping("/{concertCode}")
-    public Response<ConcertDetailResponse> getConcertDetail(
-            @NotBlank @PathVariable("concertCode") final String concertCode) {
+    public Response<ConcertDetailResponse> getConcertDetail(@PathVariable("concertCode") final String concertCode) {
         return Response.onSuccess(concertService.findDetailById(concertCode));
     }
 
     @Override
     @GetMapping
     public Response<List<RelatedConcertResponse>> getRelatedConcerts(
-            @NotBlank @RequestParam final String hallCode,
+            @RequestParam final String hallCode,
             @RequestParam(required = false) final String lastConcertCode,
-            @Positive @RequestParam(defaultValue = "3") final int pageSize) {
+            @RequestParam(defaultValue = "3") final int pageSize) {
         return Response.onSuccess(concertService.getRelatedConcerts(hallCode, lastConcertCode, pageSize));
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertControllerSwagger.java
@@ -5,19 +5,21 @@ import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailR
 import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import java.util.List;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "공연 API", description = "공연 API")
+@Tag(name = "공연 API", description = "공연 관련 API")
 public interface ConcertControllerSwagger {
 
-    @Operation(summary = "공연 상세 조회", description = "공연 상세 조회 API")
-    Response<ConcertDetailResponse> getConcertDetail(@PathVariable("concertCode") String concertCode);
+    @Operation(summary = "공연 상세 조회")
+    Response<ConcertDetailResponse> getConcertDetail(@NotBlank @PathVariable("concertCode") String concertCode);
 
     @Operation(summary = "공연장 관련 공연 목록 조회", description = "공연장 코드 기준 관련 공연 무한 스크롤")
     Response<List<RelatedConcertResponse>> getRelatedConcerts(
-            @RequestParam String hallCode,
+            @NotBlank @RequestParam String hallCode,
             @RequestParam(required = false) String lastConcertCode,
-            @RequestParam(defaultValue = "3") int pageSize);
+            @Positive @RequestParam(defaultValue = "3") int pageSize);
 }

--- a/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallController.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallController.java
@@ -3,7 +3,6 @@ package com.backend.allreva.module.concert.place.presentation;
 import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.concert.place.application.ConcertHallService;
 import com.backend.allreva.module.concert.place.application.dto.ConcertHallDetailResponse;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,8 +20,7 @@ public class ConcertHallController implements ConcertHallControllerSwagger {
 
     @Override
     @GetMapping("/{hallCode}")
-    public Response<ConcertHallDetailResponse> getConcertHallDetail(
-            @NotBlank @PathVariable("hallCode") final String hallCode) {
+    public Response<ConcertHallDetailResponse> getConcertHallDetail(@PathVariable("hallCode") final String hallCode) {
         return Response.onSuccess(concertHallService.getConcertHallDetail(hallCode));
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallControllerSwagger.java
@@ -4,11 +4,12 @@ import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.concert.place.application.dto.ConcertHallDetailResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "공연장 API", description = "공연장 관련 API")
 public interface ConcertHallControllerSwagger {
 
-    @Operation(summary = "공연장 상세 조회", description = "공연장 상세 조회 API")
-    Response<ConcertHallDetailResponse> getConcertHallDetail(@PathVariable("hallCode") String hallCode);
+    @Operation(summary = "공연장 상세 조회")
+    Response<ConcertHallDetailResponse> getConcertHallDetail(@NotBlank @PathVariable("hallCode") String hallCode);
 }

--- a/src/main/java/com/backend/allreva/module/member/presentation/MemberControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/member/presentation/MemberControllerSwagger.java
@@ -6,26 +6,31 @@ import com.backend.allreva.module.member.application.dto.MemberRegisterRequest;
 import com.backend.allreva.module.member.application.dto.RefundAccountRequest;
 import com.backend.allreva.module.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "회원 API", description = "회원 정보를 관리하는 API")
+@Tag(name = "회원 API", description = "회원 관련 API")
 public interface MemberControllerSwagger {
 
-    @Operation(summary = "회원 정보 조회 API", description = "회원 정보를 조회합니다.")
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "회원 정보 조회", description = "**[회원]**")
     Response<MemberDetailResponse> getMemberDetail(Member member);
 
-    @Operation(summary = "닉네임 중복 확인 API", description = "닉네임 중복을 확인합니다.")
+    @Operation(summary = "닉네임 중복 확인")
     Response<Boolean> isDuplicatedNickname(String nickname);
 
-    @Operation(summary = "회원 가입 API", description = "회원을 등록합니다.")
+    @Operation(summary = "회원 가입")
     Response<Void> registerMember(MemberRegisterRequest memberRegisterRequest);
 
-    @Operation(summary = "회원 프로필 수정 API", description = "회원 프로필을 수정합니다.")
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "회원 프로필 수정", description = "**[회원]**")
     Response<Void> updateMemberInfo(Member member, MemberRegisterRequest memberRegisterRequest);
 
-    @Operation(summary = "회원 환불 계좌 등록 API", description = "회원 환불 계좌를 등록합니다.")
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "환불 계좌 등록", description = "**[회원]**")
     Response<Void> registerRefundAccount(Member member, RefundAccountRequest refundAccountRequest);
 
-    @Operation(summary = "회원 환불 계좌 삭제 API", description = "회원 환불 계좌를 삭제합니다.")
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "환불 계좌 삭제", description = "**[회원]**")
     Response<Void> deleteRefundAccount(Member member);
 }

--- a/src/main/java/com/backend/allreva/module/notification/presentation/NotificationController.java
+++ b/src/main/java/com/backend/allreva/module/notification/presentation/NotificationController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/notifications")
-public class NotificationController implements NotificationSwagger {
+public class NotificationController implements NotificationControllerSwagger {
 
     private final NotificationService notificationService;
 

--- a/src/main/java/com/backend/allreva/module/notification/presentation/NotificationControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/notification/presentation/NotificationControllerSwagger.java
@@ -6,23 +6,26 @@ import com.backend.allreva.module.notification.application.dto.NotificationIdReq
 import com.backend.allreva.module.notification.application.dto.NotificationTargetRequest;
 import com.backend.allreva.module.notification.domain.Notification;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
-@Tag(name = "알림 조회 API")
-public interface NotificationSwagger {
+@Tag(name = "알림 API", description = "알림 관련 API")
+public interface NotificationControllerSwagger {
 
-    @Operation(summary = "사용자 알림 조회", description = """
-            알림 종류를 type에 입력해주세요. default값은 ALL입니다. lastId와 lastEndDate는 무한 스크롤을 위한 값입니다.
-                """)
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "알림 목록 조회", description = "**[회원]** 무한 스크롤. lastId 미전달 시 첫 페이지 조회")
     Response<List<Notification>> getNotifications(Member member, Long lastId, int pageSize);
 
-    @Operation(summary = "사용자 알림 읽음 표시", description = "알림을 클릭했을 경우 읽음 상태로 전환되는 API 입니다. 알림 ID로 알림을 찾아 읽음 표시로 변경됩니다.")
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "알림 읽음 처리", description = "**[회원]**")
     Response<Void> markAsRead(Member member, NotificationIdRequest notificationIdRequest);
 
-    @Operation(summary = "디바이스 토큰 등록")
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "디바이스 토큰 등록", description = "**[회원]**")
     Response<Void> registerDeviceToken(Member member, NotificationTargetRequest deviceTokenRequest);
 
-    @Operation(summary = "디바이스 토큰 삭제")
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "디바이스 토큰 삭제", description = "**[회원]**")
     Response<Void> deleteDeviceToken(Member member);
 }

--- a/src/main/java/com/backend/allreva/module/notification/presentation/NotificationSseController.java
+++ b/src/main/java/com/backend/allreva/module/notification/presentation/NotificationSseController.java
@@ -3,8 +3,6 @@ package com.backend.allreva.module.notification.presentation;
 import com.backend.allreva.module.auth.security.AuthMember;
 import com.backend.allreva.module.member.domain.Member;
 import com.backend.allreva.module.notification.infra.sse.SseConnectionManager;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,15 +10,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-@Tag(name = "Notification SSE API", description = "알림 SSE 구독 API")
 @RestController
 @RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
-public class NotificationSseController {
+public class NotificationSseController implements NotificationSseControllerSwagger {
 
     private final SseConnectionManager sseConnectionManager;
 
-    @Operation(summary = "SSE 구독", description = "알림 수신을 위한 SSE 연결을 수립합니다.")
+    @Override
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@AuthMember Member member) {
         return sseConnectionManager.connect(member.getId());

--- a/src/main/java/com/backend/allreva/module/notification/presentation/NotificationSseControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/notification/presentation/NotificationSseControllerSwagger.java
@@ -1,0 +1,15 @@
+package com.backend.allreva.module.notification.presentation;
+
+import com.backend.allreva.module.member.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "알림 SSE API", description = "알림 SSE 구독 관련 API")
+public interface NotificationSseControllerSwagger {
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "SSE 구독", description = "**[회원]** 알림 수신을 위한 SSE 연결 수립")
+    SseEmitter subscribe(Member member);
+}

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentController.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentController.java
@@ -16,7 +16,6 @@ import com.backend.allreva.module.recruitment.rent.application.dto.RentRegisterR
 import com.backend.allreva.module.recruitment.rent.application.dto.RentSummaryResponse;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentUpdateRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.SortType;
-import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -61,7 +60,7 @@ public class RentController implements RentControllerSwagger {
     @Override
     @PostMapping
     public Response<Long> registerRent(
-            @RequestBody @Valid final RentRegisterRequest rentRegisterRequest, @AuthMember final Member member) {
+            @RequestBody final RentRegisterRequest rentRegisterRequest, @AuthMember final Member member) {
         Long rentId = rentService.registerRent(rentRegisterRequest, member.getId());
         return Response.onSuccess(rentId);
     }
@@ -69,23 +68,21 @@ public class RentController implements RentControllerSwagger {
     @Override
     @PatchMapping
     public Response<Void> updateRent(
-            @RequestBody @Valid final RentUpdateRequest rentUpdateRequest, @AuthMember final Member member) {
+            @RequestBody final RentUpdateRequest rentUpdateRequest, @AuthMember final Member member) {
         rentService.updateRent(rentUpdateRequest, member.getId());
         return Response.onSuccess();
     }
 
     @Override
     @PatchMapping("/close")
-    public Response<Void> closeRent(
-            @RequestBody @Valid final RentIdRequest rentIdRequest, @AuthMember final Member member) {
+    public Response<Void> closeRent(@RequestBody final RentIdRequest rentIdRequest, @AuthMember final Member member) {
         rentService.closeRent(rentIdRequest, member.getId());
         return Response.onSuccess();
     }
 
     @Override
     @DeleteMapping
-    public Response<Void> deleteRent(
-            @RequestBody @Valid final RentIdRequest rentIdRequest, @AuthMember final Member member) {
+    public Response<Void> deleteRent(@RequestBody final RentIdRequest rentIdRequest, @AuthMember final Member member) {
         rentService.deleteRent(rentIdRequest, member.getId());
         return Response.onSuccess();
     }
@@ -112,7 +109,7 @@ public class RentController implements RentControllerSwagger {
     @Override
     @PostMapping("/join")
     public Response<Long> joinRent(
-            @RequestBody @Valid final RentJoinRequest rentJoinRequest, @AuthMember final Member member) {
+            @RequestBody final RentJoinRequest rentJoinRequest, @AuthMember final Member member) {
         Long participantId = rentService.joinRent(rentJoinRequest, member.getId());
         return Response.onSuccess(participantId);
     }
@@ -120,7 +117,7 @@ public class RentController implements RentControllerSwagger {
     @Override
     @PatchMapping("/join")
     public Response<Void> updateRentJoin(
-            @RequestBody @Valid final RentJoinUpdateRequest rentJoinUpdateRequest, @AuthMember final Member member) {
+            @RequestBody final RentJoinUpdateRequest rentJoinUpdateRequest, @AuthMember final Member member) {
         rentService.updateRentJoin(rentJoinUpdateRequest, member.getId());
         return Response.onSuccess();
     }
@@ -128,14 +125,14 @@ public class RentController implements RentControllerSwagger {
     @Override
     @DeleteMapping("/join")
     public Response<Void> cancelRentJoin(
-            @RequestBody @Valid final RentJoinIdRequest rentJoinIdRequest, @AuthMember final Member member) {
+            @RequestBody final RentJoinIdRequest rentJoinIdRequest, @AuthMember final Member member) {
         rentService.cancelRentJoin(rentJoinIdRequest, member.getId());
         return Response.onSuccess();
     }
 
     @Override
     @GetMapping("/me/joined")
-    public Response<List<JoinedRentResponse>> getJoinedRentSummeries(
+    public Response<List<JoinedRentResponse>> getJoinedRentSummaries(
             @AuthMember final Member member,
             @RequestParam(name = "lastId", required = false) final Long lastId,
             @RequestParam(name = "pageSize", defaultValue = "10") final int pageSize) {

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentController.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentController.java
@@ -17,7 +17,6 @@ import com.backend.allreva.module.recruitment.rent.application.dto.RentSummaryRe
 import com.backend.allreva.module.recruitment.rent.application.dto.RentUpdateRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.SortType;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -36,27 +35,30 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/rents")
-public class RentController {
+public class RentController implements RentControllerSwagger {
 
     private final RentService rentService;
 
     // Anonymous EndPoints
+    @Override
     @GetMapping("/list")
     public Response<List<RentSummaryResponse>> getRentSummaries(
             @RequestParam(name = "region", required = false) final String region,
             @RequestParam(name = "sort", defaultValue = "LATEST") final SortType sortType,
             @RequestParam(name = "lastId", required = false) final Long lastId,
             @RequestParam(name = "lastEndDate", required = false) final LocalDate lastEndDate,
-            @RequestParam(name = "pageSize", defaultValue = "10") @Min(10) final int pageSize) {
+            @RequestParam(name = "pageSize", defaultValue = "10") final int pageSize) {
         return Response.onSuccess(rentService.getRentSummaries(region, sortType, lastEndDate, lastId, pageSize));
     }
 
+    @Override
     @GetMapping("/{id}")
     public Response<RentDetailResponse> getRentDetail(@PathVariable final Long id) {
         return Response.onSuccess(rentService.getRentDetail(id));
     }
 
     // Host Endpoints
+    @Override
     @PostMapping
     public Response<Long> registerRent(
             @RequestBody @Valid final RentRegisterRequest rentRegisterRequest, @AuthMember final Member member) {
@@ -64,6 +66,7 @@ public class RentController {
         return Response.onSuccess(rentId);
     }
 
+    @Override
     @PatchMapping
     public Response<Void> updateRent(
             @RequestBody @Valid final RentUpdateRequest rentUpdateRequest, @AuthMember final Member member) {
@@ -71,6 +74,7 @@ public class RentController {
         return Response.onSuccess();
     }
 
+    @Override
     @PatchMapping("/close")
     public Response<Void> closeRent(
             @RequestBody @Valid final RentIdRequest rentIdRequest, @AuthMember final Member member) {
@@ -78,6 +82,7 @@ public class RentController {
         return Response.onSuccess();
     }
 
+    @Override
     @DeleteMapping
     public Response<Void> deleteRent(
             @RequestBody @Valid final RentIdRequest rentIdRequest, @AuthMember final Member member) {
@@ -85,14 +90,16 @@ public class RentController {
         return Response.onSuccess();
     }
 
+    @Override
     @GetMapping("/me/hosted")
     public Response<List<HostedRentSummaryResponse>> getRentHostedRentSummaries(
             @AuthMember Member member,
             @RequestParam(name = "lastId", required = false) final Long lastId,
-            @RequestParam(name = "pageSize", defaultValue = "10") @Min(10) final int pageSize) {
+            @RequestParam(name = "pageSize", defaultValue = "10") final int pageSize) {
         return Response.onSuccess(rentService.getRentHostSummaries(member.getId(), lastId, pageSize));
     }
 
+    @Override
     @GetMapping("/me/hosted/{id}")
     public Response<List<RentParticipantResponse>> getHostedRentDetail(
             @PathVariable("id") final Long rentId,
@@ -102,6 +109,7 @@ public class RentController {
     }
 
     // Participant Endpoints
+    @Override
     @PostMapping("/join")
     public Response<Long> joinRent(
             @RequestBody @Valid final RentJoinRequest rentJoinRequest, @AuthMember final Member member) {
@@ -109,6 +117,7 @@ public class RentController {
         return Response.onSuccess(participantId);
     }
 
+    @Override
     @PatchMapping("/join")
     public Response<Void> updateRentJoin(
             @RequestBody @Valid final RentJoinUpdateRequest rentJoinUpdateRequest, @AuthMember final Member member) {
@@ -116,6 +125,7 @@ public class RentController {
         return Response.onSuccess();
     }
 
+    @Override
     @DeleteMapping("/join")
     public Response<Void> cancelRentJoin(
             @RequestBody @Valid final RentJoinIdRequest rentJoinIdRequest, @AuthMember final Member member) {
@@ -123,14 +133,16 @@ public class RentController {
         return Response.onSuccess();
     }
 
+    @Override
     @GetMapping("/me/joined")
     public Response<List<JoinedRentResponse>> getJoinedRentSummeries(
             @AuthMember final Member member,
             @RequestParam(name = "lastId", required = false) final Long lastId,
-            @RequestParam(name = "pageSize", defaultValue = "10") @Min(10) final int pageSize) {
+            @RequestParam(name = "pageSize", defaultValue = "10") final int pageSize) {
         return Response.onSuccess(rentService.getJoinedRentSummaries(member.getId(), lastId, pageSize));
     }
 
+    @Override
     @GetMapping("/me/joined/{id}")
     public Response<RentParticipantResponse> getJoinedRentDetail(
             @PathVariable("id") final Long rentId,

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentControllerSwagger.java
@@ -1,0 +1,78 @@
+package com.backend.allreva.module.recruitment.rent.presentation;
+
+import com.backend.allreva.common.web.response.Response;
+import com.backend.allreva.module.member.domain.Member;
+import com.backend.allreva.module.recruitment.rent.application.dto.HostedRentSummaryResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.JoinedRentResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentDetailResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentIdRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinIdRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinUpdateRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentParticipantResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentRegisterRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentSummaryResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentUpdateRequest;
+import com.backend.allreva.module.recruitment.rent.application.dto.SortType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "차 대절 API", description = "차 대절 관련 API")
+public interface RentControllerSwagger {
+
+    @Operation(summary = "차 대절 목록 조회", description = "무한 스크롤. 정렬 기준에 따라 커서 파라미터가 다름")
+    Response<List<RentSummaryResponse>> getRentSummaries(
+            String region, SortType sortType, Long lastId, LocalDate lastEndDate, @Min(10) int pageSize);
+
+    @Operation(summary = "차 대절 상세 조회")
+    Response<RentDetailResponse> getRentDetail(Long id);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "차 대절 등록", description = "**[HOST]**")
+    Response<Long> registerRent(RentRegisterRequest rentRegisterRequest, Member member);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "차 대절 수정", description = "**[HOST]**")
+    Response<Void> updateRent(RentUpdateRequest rentUpdateRequest, Member member);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "차 대절 마감", description = "**[HOST]**")
+    Response<Void> closeRent(RentIdRequest rentIdRequest, Member member);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "차 대절 삭제", description = "**[HOST]**")
+    Response<Void> deleteRent(RentIdRequest rentIdRequest, Member member);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "내가 개설한 차 대절 목록 조회", description = "**[HOST]** 무한 스크롤")
+    Response<List<HostedRentSummaryResponse>> getRentHostedRentSummaries(
+            Member member, Long lastId, @Min(10) int pageSize);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "내가 개설한 차 대절 상세 조회", description = "**[HOST]**")
+    Response<List<RentParticipantResponse>> getHostedRentDetail(Long rentId, LocalDate boardingDate, Member member);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "차 대절 참여", description = "**[PARTICIPANT]**")
+    Response<Long> joinRent(RentJoinRequest rentJoinRequest, Member member);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "차 대절 참여 수정", description = "**[PARTICIPANT]**")
+    Response<Void> updateRentJoin(RentJoinUpdateRequest rentJoinUpdateRequest, Member member);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "차 대절 참여 취소", description = "**[PARTICIPANT]**")
+    Response<Void> cancelRentJoin(RentJoinIdRequest rentJoinIdRequest, Member member);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "내가 참여한 차 대절 목록 조회", description = "**[PARTICIPANT]** 무한 스크롤")
+    Response<List<JoinedRentResponse>> getJoinedRentSummeries(Member member, Long lastId, @Min(10) int pageSize);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "내가 참여한 차 대절 상세 조회", description = "**[PARTICIPANT]**")
+    Response<RentParticipantResponse> getJoinedRentDetail(Long rentId, LocalDate boardingDate, Member member);
+}

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentControllerSwagger.java
@@ -17,6 +17,7 @@ import com.backend.allreva.module.recruitment.rent.application.dto.SortType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
 import java.util.List;
@@ -33,19 +34,19 @@ public interface RentControllerSwagger {
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "차 대절 등록", description = "**[HOST]**")
-    Response<Long> registerRent(RentRegisterRequest rentRegisterRequest, Member member);
+    Response<Long> registerRent(@Valid RentRegisterRequest rentRegisterRequest, Member member);
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "차 대절 수정", description = "**[HOST]**")
-    Response<Void> updateRent(RentUpdateRequest rentUpdateRequest, Member member);
+    Response<Void> updateRent(@Valid RentUpdateRequest rentUpdateRequest, Member member);
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "차 대절 마감", description = "**[HOST]**")
-    Response<Void> closeRent(RentIdRequest rentIdRequest, Member member);
+    Response<Void> closeRent(@Valid RentIdRequest rentIdRequest, Member member);
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "차 대절 삭제", description = "**[HOST]**")
-    Response<Void> deleteRent(RentIdRequest rentIdRequest, Member member);
+    Response<Void> deleteRent(@Valid RentIdRequest rentIdRequest, Member member);
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "내가 개설한 차 대절 목록 조회", description = "**[HOST]** 무한 스크롤")
@@ -58,19 +59,19 @@ public interface RentControllerSwagger {
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "차 대절 참여", description = "**[PARTICIPANT]**")
-    Response<Long> joinRent(RentJoinRequest rentJoinRequest, Member member);
+    Response<Long> joinRent(@Valid RentJoinRequest rentJoinRequest, Member member);
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "차 대절 참여 수정", description = "**[PARTICIPANT]**")
-    Response<Void> updateRentJoin(RentJoinUpdateRequest rentJoinUpdateRequest, Member member);
+    Response<Void> updateRentJoin(@Valid RentJoinUpdateRequest rentJoinUpdateRequest, Member member);
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "차 대절 참여 취소", description = "**[PARTICIPANT]**")
-    Response<Void> cancelRentJoin(RentJoinIdRequest rentJoinIdRequest, Member member);
+    Response<Void> cancelRentJoin(@Valid RentJoinIdRequest rentJoinIdRequest, Member member);
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "내가 참여한 차 대절 목록 조회", description = "**[PARTICIPANT]** 무한 스크롤")
-    Response<List<JoinedRentResponse>> getJoinedRentSummeries(Member member, Long lastId, @Min(10) int pageSize);
+    Response<List<JoinedRentResponse>> getJoinedRentSummaries(Member member, Long lastId, @Min(10) int pageSize);
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "내가 참여한 차 대절 상세 조회", description = "**[PARTICIPANT]**")

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/presentation/SurveyController.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/presentation/SurveyController.java
@@ -16,7 +16,6 @@ import com.backend.allreva.module.recruitment.survey.application.dto.SurveySumma
 import com.backend.allreva.module.recruitment.survey.application.dto.UpdateSurveyRequest;
 import com.backend.allreva.module.recruitment.survey.domain.value.Region;
 import com.backend.allreva.module.recruitment.survey.exception.SurveyErrorCode;
-import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -41,15 +40,14 @@ public class SurveyController implements SurveyControllerSwagger {
 
     @Override
     @PostMapping
-    public Response<Long> openSurvey(
-            @AuthMember Member member, @Valid @RequestBody OpenSurveyRequest openSurveyRequest) {
+    public Response<Long> openSurvey(@AuthMember Member member, @RequestBody OpenSurveyRequest openSurveyRequest) {
         return Response.onSuccess(surveyService.openSurvey(member.getId(), openSurveyRequest));
     }
 
     @Override
     @PatchMapping
     public Response<Void> updateSurvey(
-            @AuthMember Member member, @Valid @RequestBody UpdateSurveyRequest updateSurveyRequest) {
+            @AuthMember Member member, @RequestBody UpdateSurveyRequest updateSurveyRequest) {
         surveyService.updateSurvey(member.getId(), updateSurveyRequest);
         return Response.onSuccess();
     }
@@ -89,8 +87,7 @@ public class SurveyController implements SurveyControllerSwagger {
 
     @Override
     @PostMapping("/apply")
-    public Response<Long> joinSurvey(
-            @AuthMember Member member, @Valid @RequestBody JoinSurveyRequest joinSurveyRequest) {
+    public Response<Long> joinSurvey(@AuthMember Member member, @RequestBody JoinSurveyRequest joinSurveyRequest) {
         return Response.onSuccess(surveyService.joinSurvey(member.getId(), joinSurveyRequest));
     }
 

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/presentation/SurveyController.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/presentation/SurveyController.java
@@ -16,10 +16,7 @@ import com.backend.allreva.module.recruitment.survey.application.dto.SurveySumma
 import com.backend.allreva.module.recruitment.survey.application.dto.UpdateSurveyRequest;
 import com.backend.allreva.module.recruitment.survey.domain.value.Region;
 import com.backend.allreva.module.recruitment.survey.exception.SurveyErrorCode;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -38,19 +35,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/surveys")
-@Tag(name = "수요조사 API Controller")
-public class SurveyController {
+public class SurveyController implements SurveyControllerSwagger {
 
     private final SurveyService surveyService;
 
-    @Operation(summary = "수요조사 개설 API", description = "수요조사를 개설합니다.")
+    @Override
     @PostMapping
     public Response<Long> openSurvey(
             @AuthMember Member member, @Valid @RequestBody OpenSurveyRequest openSurveyRequest) {
         return Response.onSuccess(surveyService.openSurvey(member.getId(), openSurveyRequest));
     }
 
-    @Operation(summary = "수요조사 수정 API", description = "수요조사를 수정합니다.")
+    @Override
     @PatchMapping
     public Response<Void> updateSurvey(
             @AuthMember Member member, @Valid @RequestBody UpdateSurveyRequest updateSurveyRequest) {
@@ -58,60 +54,47 @@ public class SurveyController {
         return Response.onSuccess();
     }
 
-    @Operation(summary = "수요조사 삭제 API", description = "수요조사를 삭제합니다.")
+    @Override
     @DeleteMapping
     public Response<Void> removeSurvey(@AuthMember Member member, @RequestBody SurveyIdRequest surveyIdRequest) {
         surveyService.removeSurvey(member.getId(), surveyIdRequest);
         return Response.onSuccess();
     }
 
-    @Operation(summary = "수요조사 상세 조회 API", description = "수요조사를 상세조회합니다.")
+    @Override
     @GetMapping("/{surveyId}")
     public Response<SurveyDetailResponse> findSurveyDetail(@PathVariable(name = "surveyId") Long surveyId) {
         return Response.onSuccess(surveyService.findSurveyDetail(surveyId));
     }
 
-    @Operation(
-            summary = "수요조사 목록 조회 API",
-            description = "수요조사 목록을 조회합니다.\n\n"
-                    + "- <b>정렬 옵션</b>:\n"
-                    + "  - 최신순 (<b>LATEST</b>): lastId를 마지막 항목의 ID로 전달. lastEndDate는 주지마세요.\n"
-                    + "  - 오래된 순 (<b>OLDEST</b>): lastId를 마지막 항목의 ID로 전달. lastEndDate는 주지마세요.\n"
-                    + "  - 마감 임박순 (<b>CLOSING</b>): 마지막 항목의 lastId와 lastEndDate를 전달하며, 둘 모두 필수입니다.\n\n"
-                    + "- <b>첫 페이지 요청</b>: lastId와 lastEndDate를 전달하지 않으면 됩니다.\n"
-                    + "- <b>기본값</b>:\n"
-                    + "  - <b>sort</b>: 최신순 (LATEST)\n"
-                    + "  - <b>pageSize</b>: 10\n"
-                    + "  - <b>region</b>: 전체 조회")
+    @Override
     @GetMapping("/list")
     public Response<List<SurveySummaryResponse>> findSurveyList(
             @RequestParam(name = "region", required = false) final Region region,
             @RequestParam(name = "sort", defaultValue = "LATEST") final SortType sortType,
             @RequestParam(name = "lastId", required = false) final Long lastId,
             @RequestParam(name = "lastEndDate", required = false) final LocalDate lastEndDate,
-            @Min(10) @RequestParam(name = "pageSize", defaultValue = "10") final int pageSize) {
+            @RequestParam(name = "pageSize", defaultValue = "10") final int pageSize) {
         if (lastEndDate != null && lastId == null) {
             throw new CustomException(SurveyErrorCode.SURVEY_ILLEGAL_PARAMETER);
         }
-        List<SurveySummaryResponse> responses =
-                surveyService.findSurveyList(region, sortType, lastId, lastEndDate, pageSize);
-        return Response.onSuccess(responses);
+        return Response.onSuccess(surveyService.findSurveyList(region, sortType, lastId, lastEndDate, pageSize));
     }
 
+    @Override
     @GetMapping("/main")
-    @Operation(summary = "첫 화면 survey API 입니다.", description = "첫 화면 survey API 입니다. 현재 날짜에서 가장 가까운 콘서트 순으로 5개 정렬")
     public Response<List<SurveySummaryResponse>> findSurveyMainList() {
         return Response.onSuccess(surveyService.findSurveyMainList());
     }
 
-    @Operation(summary = "수요조사 응답 제출 API", description = "수요조사에 대한 응답을 제출합니다.")
+    @Override
     @PostMapping("/apply")
     public Response<Long> joinSurvey(
             @AuthMember Member member, @Valid @RequestBody JoinSurveyRequest joinSurveyRequest) {
         return Response.onSuccess(surveyService.joinSurvey(member.getId(), joinSurveyRequest));
     }
 
-    @Operation(summary = "수요조사 참여 취소 API", description = "수요조사 참여를 취소합니다.")
+    @Override
     @DeleteMapping("/apply/{participantId}")
     public Response<Void> cancelJoin(
             @AuthMember Member member, @PathVariable(name = "participantId") Long participantId) {
@@ -119,28 +102,23 @@ public class SurveyController {
         return Response.onSuccess();
     }
 
-    @Operation(
-            summary = "내가 개설한 수요조사 목록 조회 API",
-            description = "첫페이지는 lastSurveyId 주지 않으셔도됩니다. 다음페이지부터는 마지막요소의 id 넣어주세요.\ndefault page size는 10입니다.")
+    @Override
     @GetMapping("/member/list")
     public Response<List<CreatedSurveyResponse>> findCreatedSurveyList(
             @AuthMember Member member,
             @RequestParam(value = "lastSurveyId", required = false) final Long lastId,
             @RequestParam(name = "lastBoardingDate", required = false) final LocalDate lastBoardingDate,
-            @Min(10) @RequestParam(value = "pageSize", defaultValue = "10") final int pageSize) {
+            @RequestParam(value = "pageSize", defaultValue = "10") final int pageSize) {
         return Response.onSuccess(
                 surveyService.findCreatedSurveyList(member.getId(), lastId, lastBoardingDate, pageSize));
     }
 
-    @Operation(
-            summary = "내가 참여한 수요조사 목록 조회 API",
-            description =
-                    "첫페이지는 lastSurveyParticipantId 주지 않으셔도됩니다. 다음페이지부터는 마지막요소의 id 넣어주세요.\ndefault page size는 10입니다.")
+    @Override
     @GetMapping("/member/apply/list")
     public Response<List<JoinSurveyResponse>> findJoinSurveyList(
             @AuthMember Member member,
             @RequestParam(value = "lastSurveyParticipantId", required = false) final Long lastId,
-            @Min(10) @RequestParam(value = "pageSize", defaultValue = "10") final int pageSize) {
+            @RequestParam(value = "pageSize", defaultValue = "10") final int pageSize) {
         return Response.onSuccess(surveyService.findJoinSurveyList(member.getId(), lastId, pageSize));
     }
 }

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/presentation/SurveyControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/presentation/SurveyControllerSwagger.java
@@ -1,0 +1,63 @@
+package com.backend.allreva.module.recruitment.survey.presentation;
+
+import com.backend.allreva.common.web.response.Response;
+import com.backend.allreva.module.member.domain.Member;
+import com.backend.allreva.module.recruitment.survey.application.dto.CreatedSurveyResponse;
+import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyRequest;
+import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyResponse;
+import com.backend.allreva.module.recruitment.survey.application.dto.OpenSurveyRequest;
+import com.backend.allreva.module.recruitment.survey.application.dto.SortType;
+import com.backend.allreva.module.recruitment.survey.application.dto.SurveyDetailResponse;
+import com.backend.allreva.module.recruitment.survey.application.dto.SurveyIdRequest;
+import com.backend.allreva.module.recruitment.survey.application.dto.SurveySummaryResponse;
+import com.backend.allreva.module.recruitment.survey.application.dto.UpdateSurveyRequest;
+import com.backend.allreva.module.recruitment.survey.domain.value.Region;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "수요조사 API", description = "수요조사 관련 API")
+public interface SurveyControllerSwagger {
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "수요조사 개설", description = "**[HOST]**")
+    Response<Long> openSurvey(Member member, OpenSurveyRequest openSurveyRequest);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "수요조사 수정", description = "**[HOST]**")
+    Response<Void> updateSurvey(Member member, UpdateSurveyRequest updateSurveyRequest);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "수요조사 삭제", description = "**[HOST]**")
+    Response<Void> removeSurvey(Member member, SurveyIdRequest surveyIdRequest);
+
+    @Operation(summary = "수요조사 상세 조회")
+    Response<SurveyDetailResponse> findSurveyDetail(Long surveyId);
+
+    @Operation(summary = "수요조사 목록 조회", description = "무한 스크롤. CLOSING 정렬 시 lastId + lastEndDate 모두 필요")
+    Response<List<SurveySummaryResponse>> findSurveyList(
+            Region region, SortType sortType, Long lastId, LocalDate lastEndDate, @Min(10) int pageSize);
+
+    @Operation(summary = "메인 수요조사 목록 조회", description = "가장 가까운 콘서트 순 5개")
+    Response<List<SurveySummaryResponse>> findSurveyMainList();
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "수요조사 참여", description = "**[PARTICIPANT]**")
+    Response<Long> joinSurvey(Member member, JoinSurveyRequest joinSurveyRequest);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "수요조사 참여 취소", description = "**[PARTICIPANT]**")
+    Response<Void> cancelJoin(Member member, Long participantId);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "내가 개설한 수요조사 목록 조회", description = "**[HOST]** 무한 스크롤")
+    Response<List<CreatedSurveyResponse>> findCreatedSurveyList(
+            Member member, Long lastId, LocalDate lastBoardingDate, @Min(10) int pageSize);
+
+    @SecurityRequirement(name = "USER")
+    @Operation(summary = "내가 참여한 수요조사 목록 조회", description = "**[PARTICIPANT]** 무한 스크롤")
+    Response<List<JoinSurveyResponse>> findJoinSurveyList(Member member, Long lastId, @Min(10) int pageSize);
+}

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/presentation/SurveyControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/presentation/SurveyControllerSwagger.java
@@ -15,6 +15,7 @@ import com.backend.allreva.module.recruitment.survey.domain.value.Region;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
 import java.util.List;
@@ -24,11 +25,11 @@ public interface SurveyControllerSwagger {
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "수요조사 개설", description = "**[HOST]**")
-    Response<Long> openSurvey(Member member, OpenSurveyRequest openSurveyRequest);
+    Response<Long> openSurvey(Member member, @Valid OpenSurveyRequest openSurveyRequest);
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "수요조사 수정", description = "**[HOST]**")
-    Response<Void> updateSurvey(Member member, UpdateSurveyRequest updateSurveyRequest);
+    Response<Void> updateSurvey(Member member, @Valid UpdateSurveyRequest updateSurveyRequest);
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "수요조사 삭제", description = "**[HOST]**")
@@ -46,7 +47,7 @@ public interface SurveyControllerSwagger {
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "수요조사 참여", description = "**[PARTICIPANT]**")
-    Response<Long> joinSurvey(Member member, JoinSurveyRequest joinSurveyRequest);
+    Response<Long> joinSurvey(Member member, @Valid JoinSurveyRequest joinSurveyRequest);
 
     @SecurityRequirement(name = "USER")
     @Operation(summary = "수요조사 참여 취소", description = "**[PARTICIPANT]**")

--- a/src/main/java/com/backend/allreva/module/search/presentation/SearchController.java
+++ b/src/main/java/com/backend/allreva/module/search/presentation/SearchController.java
@@ -16,9 +16,6 @@ import com.backend.allreva.module.search.application.dto.RentThumbnail;
 import com.backend.allreva.module.search.application.dto.SortDirection;
 import com.backend.allreva.module.search.application.dto.SurveySearchListResponse;
 import com.backend.allreva.module.search.application.dto.SurveyThumbnail;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,11 +23,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "검색 API", description = "통합 검색 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/search")
-public class SearchController {
+public class SearchController implements SearchControllerSwagger {
 
     private final PopularKeywordService popularKeywordService;
     private final ConcertSearchService concertSearchService;
@@ -38,67 +34,67 @@ public class SearchController {
     private final RentSearchService rentSearchService;
     private final SurveySearchService surveySearchService;
 
-    @Operation(summary = "인기검색어 Top 10 조회", description = "인기검색어 Top 10을 조회합니다.")
+    @Override
     @GetMapping("/popular")
     public Response<List<PopularKeywordResponse>> getPopularKeywordRank() {
         return Response.onSuccess(popularKeywordService.getPopularKeywordRank());
     }
 
-    @Operation(summary = "콘서트 검색시 상위 2개 썸네일 API", description = "콘서트 검색어에 따라 관련도 상위 2개의 썸네일에 필요한 정보를 출력")
+    @Override
     @GetMapping("/concert/")
     public Response<List<ConcertThumbnail>> searchConcertThumbnail(@RequestParam final String query) {
         return Response.onSuccess(concertSearchService.searchConcertThumbnails(query));
     }
 
-    @Operation(summary = "콘서트 검색 더보기 API", description = "콘서트 검색어에 따라 관련도 순으로 무한 스크롤")
+    @Override
     @GetMapping("/concert/list")
     public Response<ConcertSearchListResponse> searchConcertList(
-            @RequestParam @NotEmpty(message = "검색어를 입력해야 합니다.") final String query,
+            @RequestParam final String query,
             @RequestParam(defaultValue = "7") final int pageSize,
             @RequestParam(required = false) final String cursorCode) {
         return Response.onSuccess(concertSearchService.searchConcertList(query, cursorCode, pageSize));
     }
 
-    @Operation(summary = "전체 기간 콘서트 검색 API", description = "과거와 현재 모든 콘서트를 검색하는 API입니다.")
+    @Override
     @GetMapping("/concert/list/all")
     public Response<ConcertSearchListResponse> searchAllConcertList(
-            @RequestParam @NotEmpty(message = "검색어를 입력해야 합니다.") final String query,
+            @RequestParam final String query,
             @RequestParam(defaultValue = "7") final int pageSize,
             @RequestParam(required = false) final String cursorCode) {
         return Response.onSuccess(concertSearchService.searchAllConcertList(query, cursorCode, pageSize));
     }
 
-    @Operation(summary = "전체 검색시 렌트 상위 2개 썸네일 API", description = "검색어에 따라 관련도 상위 2개의 썸네일에 필요한 정보를 출력")
+    @Override
     @GetMapping("/rents/")
     public Response<List<RentThumbnail>> searchRentThumbnail(@RequestParam final String query) {
         return Response.onSuccess(rentSearchService.searchRentThumbnails(query));
     }
 
-    @Operation(summary = "렌트 검색 더보기 API", description = "검색어에 따라 관련도 순으로 무한 스크롤")
+    @Override
     @GetMapping("/rents/list")
     public Response<RentSearchListResponse> searchRentList(
-            @RequestParam @NotEmpty(message = "검색어를 입력해야 합니다.") final String query,
+            @RequestParam final String query,
             @RequestParam(defaultValue = "7") final int pageSize,
             @RequestParam(required = false) final Long cursorId) {
         return Response.onSuccess(rentSearchService.searchRentSearchList(query, cursorId, pageSize));
     }
 
-    @Operation(summary = "전체 검색시 수요조사 상위 2개 썸네일 API", description = "검색어에 따라 관련도 상위 2개의 썸네일에 필요한 정보를 출력")
+    @Override
     @GetMapping("/surveys/")
     public Response<List<SurveyThumbnail>> searchSurveyThumbnail(@RequestParam final String query) {
         return Response.onSuccess(surveySearchService.searchSurveyThumbnails(query));
     }
 
-    @Operation(summary = "수요조사 검색 더보기 API", description = "검색어에 따라 관련도 순으로 무한 스크롤")
+    @Override
     @GetMapping("/surveys/list")
     public Response<SurveySearchListResponse> searchSurveyList(
-            @RequestParam @NotEmpty(message = "검색어를 입력해야 합니다.") final String query,
+            @RequestParam final String query,
             @RequestParam(defaultValue = "7") final int pageSize,
             @RequestParam(required = false) final Long cursorId) {
         return Response.onSuccess(surveySearchService.searchSurveyList(query, cursorId, pageSize));
     }
 
-    @Operation(summary = "메인 화면 콘서트 API", description = "지역별/정렬 기준으로 콘서트 목록 조회")
+    @Override
     @GetMapping("/concert/main")
     public Response<ConcertMainResponse> getConcertMainList(
             @RequestParam(defaultValue = "") final String region,
@@ -108,7 +104,7 @@ public class SearchController {
         return Response.onSuccess(concertSearchService.searchMainConcerts(region, cursorCode, pageSize, sortDirection));
     }
 
-    @Operation(summary = "메인 화면 공연장 API", description = "주소/좌석 기준으로 공연장 목록 조회")
+    @Override
     @GetMapping("/place/main")
     public Response<ConcertHallMainResponse> getPlaceMainList(
             @RequestParam(defaultValue = "") final String address,

--- a/src/main/java/com/backend/allreva/module/search/presentation/SearchController.java
+++ b/src/main/java/com/backend/allreva/module/search/presentation/SearchController.java
@@ -18,11 +18,13 @@ import com.backend.allreva.module.search.application.dto.SurveySearchListRespons
 import com.backend.allreva.module.search.application.dto.SurveyThumbnail;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/search")

--- a/src/main/java/com/backend/allreva/module/search/presentation/SearchControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/search/presentation/SearchControllerSwagger.java
@@ -26,22 +26,26 @@ public interface SearchControllerSwagger {
     Response<List<ConcertThumbnail>> searchConcertThumbnail(String query);
 
     @Operation(summary = "콘서트 검색 목록 조회", description = "무한 스크롤. 관련도 순 정렬")
-    Response<ConcertSearchListResponse> searchConcertList(@NotEmpty String query, int pageSize, String cursorCode);
+    Response<ConcertSearchListResponse> searchConcertList(
+            @NotEmpty(message = "검색어를 입력해야 합니다.") String query, int pageSize, String cursorCode);
 
     @Operation(summary = "전체 기간 콘서트 검색 목록 조회", description = "과거 포함 전체 콘서트 무한 스크롤")
-    Response<ConcertSearchListResponse> searchAllConcertList(@NotEmpty String query, int pageSize, String cursorCode);
+    Response<ConcertSearchListResponse> searchAllConcertList(
+            @NotEmpty(message = "검색어를 입력해야 합니다.") String query, int pageSize, String cursorCode);
 
     @Operation(summary = "차 대절 썸네일 검색", description = "검색어 관련도 상위 2개")
     Response<List<RentThumbnail>> searchRentThumbnail(String query);
 
     @Operation(summary = "차 대절 검색 목록 조회", description = "무한 스크롤. 관련도 순 정렬")
-    Response<RentSearchListResponse> searchRentList(@NotEmpty String query, int pageSize, Long cursorId);
+    Response<RentSearchListResponse> searchRentList(
+            @NotEmpty(message = "검색어를 입력해야 합니다.") String query, int pageSize, Long cursorId);
 
     @Operation(summary = "수요조사 썸네일 검색", description = "검색어 관련도 상위 2개")
     Response<List<SurveyThumbnail>> searchSurveyThumbnail(String query);
 
     @Operation(summary = "수요조사 검색 목록 조회", description = "무한 스크롤. 관련도 순 정렬")
-    Response<SurveySearchListResponse> searchSurveyList(@NotEmpty String query, int pageSize, Long cursorId);
+    Response<SurveySearchListResponse> searchSurveyList(
+            @NotEmpty(message = "검색어를 입력해야 합니다.") String query, int pageSize, Long cursorId);
 
     @Operation(summary = "메인 콘서트 목록 조회", description = "지역별/정렬 기준으로 콘서트 목록 조회")
     Response<ConcertMainResponse> getConcertMainList(

--- a/src/main/java/com/backend/allreva/module/search/presentation/SearchControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/search/presentation/SearchControllerSwagger.java
@@ -1,0 +1,52 @@
+package com.backend.allreva.module.search.presentation;
+
+import com.backend.allreva.common.web.response.Response;
+import com.backend.allreva.module.concert.place.application.dto.ConcertHallMainResponse;
+import com.backend.allreva.module.search.application.dto.ConcertMainResponse;
+import com.backend.allreva.module.search.application.dto.ConcertSearchListResponse;
+import com.backend.allreva.module.search.application.dto.ConcertThumbnail;
+import com.backend.allreva.module.search.application.dto.PopularKeywordResponse;
+import com.backend.allreva.module.search.application.dto.RentSearchListResponse;
+import com.backend.allreva.module.search.application.dto.RentThumbnail;
+import com.backend.allreva.module.search.application.dto.SortDirection;
+import com.backend.allreva.module.search.application.dto.SurveySearchListResponse;
+import com.backend.allreva.module.search.application.dto.SurveyThumbnail;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+@Tag(name = "검색 API", description = "통합 검색 관련 API")
+public interface SearchControllerSwagger {
+
+    @Operation(summary = "인기 검색어 Top 10 조회")
+    Response<List<PopularKeywordResponse>> getPopularKeywordRank();
+
+    @Operation(summary = "콘서트 썸네일 검색", description = "검색어 관련도 상위 2개")
+    Response<List<ConcertThumbnail>> searchConcertThumbnail(String query);
+
+    @Operation(summary = "콘서트 검색 목록 조회", description = "무한 스크롤. 관련도 순 정렬")
+    Response<ConcertSearchListResponse> searchConcertList(@NotEmpty String query, int pageSize, String cursorCode);
+
+    @Operation(summary = "전체 기간 콘서트 검색 목록 조회", description = "과거 포함 전체 콘서트 무한 스크롤")
+    Response<ConcertSearchListResponse> searchAllConcertList(@NotEmpty String query, int pageSize, String cursorCode);
+
+    @Operation(summary = "차 대절 썸네일 검색", description = "검색어 관련도 상위 2개")
+    Response<List<RentThumbnail>> searchRentThumbnail(String query);
+
+    @Operation(summary = "차 대절 검색 목록 조회", description = "무한 스크롤. 관련도 순 정렬")
+    Response<RentSearchListResponse> searchRentList(@NotEmpty String query, int pageSize, Long cursorId);
+
+    @Operation(summary = "수요조사 썸네일 검색", description = "검색어 관련도 상위 2개")
+    Response<List<SurveyThumbnail>> searchSurveyThumbnail(String query);
+
+    @Operation(summary = "수요조사 검색 목록 조회", description = "무한 스크롤. 관련도 순 정렬")
+    Response<SurveySearchListResponse> searchSurveyList(@NotEmpty String query, int pageSize, Long cursorId);
+
+    @Operation(summary = "메인 콘서트 목록 조회", description = "지역별/정렬 기준으로 콘서트 목록 조회")
+    Response<ConcertMainResponse> getConcertMainList(
+            String region, SortDirection sortDirection, int pageSize, String cursorCode);
+
+    @Operation(summary = "메인 공연장 목록 조회", description = "주소/좌석 기준으로 공연장 목록 조회")
+    Response<ConcertHallMainResponse> getPlaceMainList(String address, int seatScale, int pageSize, String cursorId);
+}


### PR DESCRIPTION
## 작업 내용

구현체에서 인터페이스 메서드의 파라미터 제약을 재정의하면 HV000151이 발생함.
`ConcertController`, `ConcertHallController`가 해당 케이스였고, 인터페이스 부재로 Swagger 없는 Controller도 같이 정리.

## 구현

- `@NotBlank`, `@Positive`, `@Min`, `@NotEmpty` 제약을 구현체 → 인터페이스로 이동
- Swagger 없는 Controller 5개에 `*ControllerSwagger` 인터페이스 생성 (Rent, Survey, Search, NotificationSse, PresignedUrl)
- `NotificationSwagger` → `NotificationControllerSwagger` 네이밍 통일
- `@SecurityRequirement` + `[회원]`/`[HOST]`/`[PARTICIPANT]` role 표시 추가
- `SwaggerConfig` 전역 security 제거, 엔드포인트별 개별 적용

## 테스트

N/A

Closes #53