### PR TITLE
[#42] Concert/ConcertHall Caffeine 로컬 캐시 적용

### DIFF
--- a/src/main/java/com/backend/allreva/common/config/CacheConfig.java
+++ b/src/main/java/com/backend/allreva/common/config/CacheConfig.java
@@ -18,19 +18,20 @@ public class CacheConfig {
     public CacheManager cacheManager() {
         SimpleCacheManager manager = new SimpleCacheManager();
         manager.setCaches(List.of(
-                build("concertMain",     100, Duration.ofDays(1)),
-                build("concertSearch",   500, Duration.ofHours(1)),
-                build("concertRelated",  200, Duration.ofHours(1)),
-                build("concertHall",     200, Duration.ofDays(30))
-        ));
+                build("concertMain", 100, Duration.ofDays(1)),
+                build("concertSearch", 500, Duration.ofHours(1)),
+                build("concertRelated", 200, Duration.ofHours(1)),
+                build("concertHall", 200, Duration.ofDays(30))));
         return manager;
     }
 
     private CaffeineCache build(String name, int maxSize, Duration ttl) {
-        return new CaffeineCache(name, Caffeine.newBuilder()
-                .maximumSize(maxSize)
-                .expireAfterWrite(ttl)
-                .recordStats()
-                .build());
+        return new CaffeineCache(
+                name,
+                Caffeine.newBuilder()
+                        .maximumSize(maxSize)
+                        .expireAfterWrite(ttl)
+                        .recordStats()
+                        .build());
     }
 }

--- a/src/main/java/com/backend/allreva/common/config/CacheConfig.java
+++ b/src/main/java/com/backend/allreva/common/config/CacheConfig.java
@@ -2,48 +2,35 @@ package com.backend.allreva.common.config;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCache;
-import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 
 @EnableCaching
 @Configuration
 public class CacheConfig {
-    @Bean
-    @Primary
-    public CacheManager placeMainCacheManager() {
-        ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager("placeMainCacheManager");
-        cacheManager.setCacheNames(List.of("placeMain"));
-        return cacheManager;
-    }
 
     @Bean
-    public CacheManager relatedConcertCacheManager() {
-        SimpleCacheManager cacheManager = new SimpleCacheManager();
-
-        // relatedConcert 캐시 설정
-        CaffeineCache relatedConcertCache = new CaffeineCache(
-                "relatedConcert",
-                Caffeine.newBuilder()
-                        .expireAfterWrite(Duration.ofSeconds(calculateSecondsUntilMidnight())) // 자정까지 TTL 설정
-                        .maximumSize(100) // 최대 캐시 크기
-                        .build());
-
-        cacheManager.setCaches(List.of(relatedConcertCache));
-        return cacheManager;
+    public CacheManager cacheManager() {
+        SimpleCacheManager manager = new SimpleCacheManager();
+        manager.setCaches(List.of(
+                build("concertMain",     100, Duration.ofDays(1)),
+                build("concertSearch",   500, Duration.ofHours(1)),
+                build("concertRelated",  200, Duration.ofHours(1)),
+                build("concertHall",     200, Duration.ofDays(30))
+        ));
+        return manager;
     }
 
-    private long calculateSecondsUntilMidnight() {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime midnight = now.toLocalDate().plusDays(1).atStartOfDay(); // 다음 날 00:00
-        return ChronoUnit.SECONDS.between(now, midnight);
+    private CaffeineCache build(String name, int maxSize, Duration ttl) {
+        return new CaffeineCache(name, Caffeine.newBuilder()
+                .maximumSize(maxSize)
+                .expireAfterWrite(ttl)
+                .recordStats()
+                .build());
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
@@ -39,6 +39,7 @@ public class ConcertService {
         return thumbnails;
     }
 
+    @Cacheable(cacheNames = "concertSearch", key = "#title + '_' + #cursorCode + '_' + #size")
     @Transactional(readOnly = true)
     public SliceResponse<ConcertThumbnail, String> searchConcerts(
             final String title, final String cursorCode, final int size) {
@@ -50,6 +51,7 @@ public class ConcertService {
         return response;
     }
 
+    @Cacheable(cacheNames = "concertMain", key = "#address + '_' + #cursorCode + '_' + #size + '_' + #sortDirection.name()")
     @Transactional(readOnly = true)
     public SliceResponse<ConcertThumbnail, String> getMainConcerts(
             final String address, final String cursorCode, final int size, final SortDirection sortDirection) {
@@ -61,12 +63,8 @@ public class ConcertService {
         return response;
     }
 
+    @Cacheable(cacheNames = "concertRelated", key = "#hallCode + '_' + #lastConcertCode + '_' + #pageSize")
     @Transactional(readOnly = true)
-    @Cacheable(
-            cacheNames = "relatedConcert",
-            key = "#hallCode + '_' + #lastConcertCode + '_' + #pageSize",
-            unless = "#result == null",
-            cacheManager = "relatedConcertCacheManager")
     public List<RelatedConcertResponse> getRelatedConcerts(
             final String hallCode, final String lastConcertCode, final int pageSize) {
         return concertRepository.findAllByHallCode(hallCode, lastConcertCode, pageSize).stream()

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
@@ -51,7 +51,9 @@ public class ConcertService {
         return response;
     }
 
-    @Cacheable(cacheNames = "concertMain", key = "#address + '_' + #cursorCode + '_' + #size + '_' + #sortDirection.name()")
+    @Cacheable(
+            cacheNames = "concertMain",
+            key = "#address + '_' + #cursorCode + '_' + #size + '_' + #sortDirection.name()")
     @Transactional(readOnly = true)
     public SliceResponse<ConcertThumbnail, String> getMainConcerts(
             final String address, final String cursorCode, final int size, final SortDirection sortDirection) {

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
@@ -39,7 +39,7 @@ public class ConcertService {
         return thumbnails;
     }
 
-    @Cacheable(cacheNames = "concertSearch", key = "#title + '_' + #cursorCode + '_' + #size")
+    @Cacheable(cacheNames = "concertSearch")
     @Transactional(readOnly = true)
     public SliceResponse<ConcertThumbnail, String> searchConcerts(
             final String title, final String cursorCode, final int size) {
@@ -51,9 +51,7 @@ public class ConcertService {
         return response;
     }
 
-    @Cacheable(
-            cacheNames = "concertMain",
-            key = "#address + '_' + #cursorCode + '_' + #size + '_' + #sortDirection.name()")
+    @Cacheable(cacheNames = "concertMain")
     @Transactional(readOnly = true)
     public SliceResponse<ConcertThumbnail, String> getMainConcerts(
             final String address, final String cursorCode, final int size, final SortDirection sortDirection) {
@@ -65,7 +63,7 @@ public class ConcertService {
         return response;
     }
 
-    @Cacheable(cacheNames = "concertRelated", key = "#hallCode + '_' + #lastConcertCode + '_' + #pageSize")
+    @Cacheable(cacheNames = "concertRelated")
     @Transactional(readOnly = true)
     public List<RelatedConcertResponse> getRelatedConcerts(
             final String hallCode, final String lastConcertCode, final int pageSize) {

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertSyncScheduler.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertSyncScheduler.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -28,6 +29,7 @@ public class ConcertSyncScheduler {
     private final ConcertRepository concertRepository;
 
     /** 공연 정보 매일 동기화 — 매일 새벽 4시 */
+    @CacheEvict(cacheNames = {"concertMain", "concertSearch"}, allEntries = true)
     @Scheduled(cron = "0 0 4 * * *")
     public void fetchDailyScheduled() {
         LocalDate today = LocalDate.now();
@@ -39,6 +41,7 @@ public class ConcertSyncScheduler {
         }
     }
 
+    @CacheEvict(cacheNames = {"concertMain", "concertSearch"}, allEntries = true)
     public void fetchDailyConcertInfoList(final LocalDate today) {
         List<String> hallCodes = concertHallRepository.findAllHallCodes();
         Map<String, ConcertStatus> statusMap = concertRepository.findAll().stream()

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertSyncScheduler.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertSyncScheduler.java
@@ -30,7 +30,7 @@ public class ConcertSyncScheduler {
 
     /** 공연 정보 매일 동기화 — 매일 새벽 4시 */
     @CacheEvict(
-            cacheNames = {"concertMain", "concertSearch"},
+            cacheNames = {"concertMain", "concertSearch", "concertRelated"},
             allEntries = true)
     @Scheduled(cron = "0 0 4 * * *")
     public void fetchDailyScheduled() {
@@ -44,7 +44,7 @@ public class ConcertSyncScheduler {
     }
 
     @CacheEvict(
-            cacheNames = {"concertMain", "concertSearch"},
+            cacheNames = {"concertMain", "concertSearch", "concertRelated"},
             allEntries = true)
     public void fetchDailyConcertInfoList(final LocalDate today) {
         List<String> hallCodes = concertHallRepository.findAllHallCodes();

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertSyncScheduler.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertSyncScheduler.java
@@ -29,7 +29,9 @@ public class ConcertSyncScheduler {
     private final ConcertRepository concertRepository;
 
     /** 공연 정보 매일 동기화 — 매일 새벽 4시 */
-    @CacheEvict(cacheNames = {"concertMain", "concertSearch"}, allEntries = true)
+    @CacheEvict(
+            cacheNames = {"concertMain", "concertSearch"},
+            allEntries = true)
     @Scheduled(cron = "0 0 4 * * *")
     public void fetchDailyScheduled() {
         LocalDate today = LocalDate.now();
@@ -41,7 +43,9 @@ public class ConcertSyncScheduler {
         }
     }
 
-    @CacheEvict(cacheNames = {"concertMain", "concertSearch"}, allEntries = true)
+    @CacheEvict(
+            cacheNames = {"concertMain", "concertSearch"},
+            allEntries = true)
     public void fetchDailyConcertInfoList(final LocalDate today) {
         List<String> hallCodes = concertHallRepository.findAllHallCodes();
         Map<String, ConcertStatus> statusMap = concertRepository.findAll().stream()

--- a/src/main/java/com/backend/allreva/module/concert/concert/infra/ConcertSearchRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/infra/ConcertSearchRepositoryImpl.java
@@ -1,11 +1,12 @@
 package com.backend.allreva.module.concert.concert.infra;
 
+import static com.backend.allreva.module.concert.concert.domain.QConcert.concert;
+import static com.backend.allreva.module.concert.place.domain.QConcertHall.concertHall;
+
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertThumbnail;
 import com.backend.allreva.module.concert.concert.application.dto.SortDirection;
 import com.backend.allreva.module.concert.concert.application.port.ConcertSearchRepository;
-import com.backend.allreva.module.concert.concert.domain.QConcert;
-import com.backend.allreva.module.concert.place.domain.QConcertHall;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -23,8 +24,6 @@ public class ConcertSearchRepositoryImpl implements ConcertSearchRepository {
 
     private static final double SIMILARITY_THRESHOLD = 0.1;
     private final JPAQueryFactory queryFactory;
-    private final QConcert concert = QConcert.concert;
-    private final QConcertHall hall = QConcertHall.concertHall;
 
     @Override
     public List<ConcertThumbnail> findThumbnailsByTitle(final String title, final int limit) {
@@ -33,13 +32,13 @@ public class ConcertSearchRepositoryImpl implements ConcertSearchRepository {
                         ConcertThumbnail.class,
                         concert.poster.url,
                         concert.concertInfo.title,
-                        hall.name,
+                        concertHall.name,
                         concert.concertInfo.dateInfo.startDate,
                         concert.concertInfo.dateInfo.endDate,
                         concert.concertCode))
                 .from(concert)
-                .leftJoin(hall)
-                .on(concert.hallCode.eq(hall.hallCode))
+                .leftJoin(concertHall)
+                .on(concert.hallCode.eq(concertHall.hallCode))
                 .where(titleMatchCondition(title))
                 .orderBy(similarityOrder(title), concert.concertCode.desc())
                 .limit(limit)
@@ -58,7 +57,7 @@ public class ConcertSearchRepositoryImpl implements ConcertSearchRepository {
     public SliceResponse<ConcertThumbnail, String> findAllByAddressAndSortDirection(
             final String address, final String cursorCode, final int pageSize, final SortDirection sortDirection) {
         BooleanExpression addressCondition = StringUtils.hasText(address)
-                ? Expressions.booleanTemplate("({0} ilike {1})", hall.location.address, "%" + address + "%")
+                ? Expressions.booleanTemplate("({0} ilike {1})", concertHall.location.address, "%" + address + "%")
                 : null;
 
         List<ConcertThumbnail> results = fetchConcerts(
@@ -80,13 +79,13 @@ public class ConcertSearchRepositoryImpl implements ConcertSearchRepository {
                         ConcertThumbnail.class,
                         concert.poster.url,
                         concert.concertInfo.title,
-                        hall.name,
+                        concertHall.name,
                         concert.concertInfo.dateInfo.startDate,
                         concert.concertInfo.dateInfo.endDate,
                         concert.concertCode))
                 .from(concert)
-                .leftJoin(hall)
-                .on(concert.hallCode.eq(hall.hallCode))
+                .leftJoin(concertHall)
+                .on(concert.hallCode.eq(concertHall.hallCode))
                 .where(searchCondition, cursorCondition)
                 .orderBy(primarySort, concert.concertCode.desc())
                 .limit(fetchSize)

--- a/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertSyncTestController.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertSyncTestController.java
@@ -1,0 +1,28 @@
+package com.backend.allreva.module.concert.concert.presentation;
+
+import com.backend.allreva.module.concert.concert.application.ConcertSyncScheduler;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("!prod")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/test/sync/concerts")
+public class ConcertSyncTestController implements ConcertSyncTestControllerSwagger {
+
+    private final ConcertSyncScheduler concertSyncScheduler;
+
+    @PostMapping
+    public String syncConcerts(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        LocalDate target = date != null ? date : LocalDate.now();
+        concertSyncScheduler.fetchDailyConcertInfoList(target);
+        return "concert sync triggered for " + target;
+    }
+}

--- a/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertSyncTestControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertSyncTestControllerSwagger.java
@@ -1,0 +1,12 @@
+package com.backend.allreva.module.concert.concert.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+
+@Tag(name = "[테스트] 공연 동기화 API", description = "테스트용 KOPIS 공연 정보 동기화 수동 트리거 API")
+public interface ConcertSyncTestControllerSwagger {
+
+    @Operation(summary = "공연 정보 동기화 트리거", description = "KOPIS에서 공연 정보를 수동으로 동기화합니다. date 미입력 시 오늘 날짜 기준으로 실행됩니다.")
+    String syncConcerts(LocalDate date);
+}

--- a/src/main/java/com/backend/allreva/module/concert/place/application/ConcertHallService.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/application/ConcertHallService.java
@@ -7,6 +7,7 @@ import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
 import com.backend.allreva.module.concert.place.exception.ConcertHallErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +18,7 @@ public class ConcertHallService {
 
     private final ConcertHallRepository concertHallRepository;
 
+    @Cacheable(cacheNames = "concertHall", key = "#hallCode")
     @Transactional(readOnly = true)
     public ConcertHallDetailResponse getConcertHallDetail(final String hallCode) {
         ConcertHall hall = concertHallRepository

--- a/src/main/java/com/backend/allreva/module/concert/place/application/ConcertHallSyncScheduler.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/application/ConcertHallSyncScheduler.java
@@ -23,7 +23,7 @@ public class ConcertHallSyncScheduler {
 
     /** 공연장 정보 매월 동기화 — 매월 1일 새벽 2시 */
     @CacheEvict(
-            cacheNames = {"concertHall", "concertHallSearch"},
+            cacheNames = {"concertHall"},
             allEntries = true)
     @Scheduled(cron = "0 0 2 1 * *")
     public void fetchMonthlyHallInfoList() {
@@ -36,7 +36,7 @@ public class ConcertHallSyncScheduler {
     }
 
     @CacheEvict(
-            cacheNames = {"concertHall", "concertHallSearch"},
+            cacheNames = {"concertHall"},
             allEntries = true)
     public void fetchConcertHallInfoList() {
         Set<String> facilityCodes = concertHallRepository.findAllFacilityCodes();

--- a/src/main/java/com/backend/allreva/module/concert/place/application/ConcertHallSyncScheduler.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/application/ConcertHallSyncScheduler.java
@@ -22,6 +22,7 @@ public class ConcertHallSyncScheduler {
     private final ConcertHallRepository concertHallRepository;
 
     /** 공연장 정보 매월 동기화 — 매월 1일 새벽 2시 */
+    @CacheEvict(cacheNames = {"concertHall", "concertHallSearch"}, allEntries = true)
     @Scheduled(cron = "0 0 2 1 * *")
     public void fetchMonthlyHallInfoList() {
         try {
@@ -32,7 +33,7 @@ public class ConcertHallSyncScheduler {
         }
     }
 
-    @CacheEvict(cacheNames = "placeMain", allEntries = true)
+    @CacheEvict(cacheNames = {"concertHall", "concertHallSearch"}, allEntries = true)
     public void fetchConcertHallInfoList() {
         Set<String> facilityCodes = concertHallRepository.findAllFacilityCodes();
 

--- a/src/main/java/com/backend/allreva/module/concert/place/application/ConcertHallSyncScheduler.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/application/ConcertHallSyncScheduler.java
@@ -22,7 +22,9 @@ public class ConcertHallSyncScheduler {
     private final ConcertHallRepository concertHallRepository;
 
     /** 공연장 정보 매월 동기화 — 매월 1일 새벽 2시 */
-    @CacheEvict(cacheNames = {"concertHall", "concertHallSearch"}, allEntries = true)
+    @CacheEvict(
+            cacheNames = {"concertHall", "concertHallSearch"},
+            allEntries = true)
     @Scheduled(cron = "0 0 2 1 * *")
     public void fetchMonthlyHallInfoList() {
         try {
@@ -33,7 +35,9 @@ public class ConcertHallSyncScheduler {
         }
     }
 
-    @CacheEvict(cacheNames = {"concertHall", "concertHallSearch"}, allEntries = true)
+    @CacheEvict(
+            cacheNames = {"concertHall", "concertHallSearch"},
+            allEntries = true)
     public void fetchConcertHallInfoList() {
         Set<String> facilityCodes = concertHallRepository.findAllFacilityCodes();
 

--- a/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallSyncTestController.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallSyncTestController.java
@@ -1,0 +1,23 @@
+package com.backend.allreva.module.concert.place.presentation;
+
+import com.backend.allreva.module.concert.place.application.ConcertHallSyncScheduler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("!prod")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/test/sync/halls")
+public class ConcertHallSyncTestController implements ConcertHallSyncTestControllerSwagger {
+
+    private final ConcertHallSyncScheduler concertHallSyncScheduler;
+
+    @PostMapping
+    public String syncHalls() {
+        concertHallSyncScheduler.fetchConcertHallInfoList();
+        return "concert hall sync triggered";
+    }
+}

--- a/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallSyncTestControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallSyncTestControllerSwagger.java
@@ -1,0 +1,11 @@
+package com.backend.allreva.module.concert.place.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[테스트] 공연장 동기화 API", description = "테스트용 KOPIS 공연장 정보 동기화 수동 트리거 API")
+public interface ConcertHallSyncTestControllerSwagger {
+
+    @Operation(summary = "공연장 정보 동기화 트리거", description = "KOPIS에서 공연장 정보를 수동으로 동기화합니다.")
+    String syncHalls();
+}

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/infra/RentSearchRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/infra/RentSearchRepositoryImpl.java
@@ -1,9 +1,10 @@
 package com.backend.allreva.module.recruitment.rent.infra;
 
+import static com.backend.allreva.module.recruitment.rent.domain.QRent.rent;
+
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentThumbnail;
 import com.backend.allreva.module.recruitment.rent.application.port.RentSearchRepository;
-import com.backend.allreva.module.recruitment.rent.domain.QRent;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -21,7 +22,6 @@ public class RentSearchRepositoryImpl implements RentSearchRepository {
 
     private static final double SIMILARITY_THRESHOLD = 0.1;
     private final JPAQueryFactory queryFactory;
-    private final QRent rent = QRent.rent;
 
     @Override
     public List<RentThumbnail> findThumbnailsByTitle(final String title, final int limit) {

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/infra/SurveySearchRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/infra/SurveySearchRepositoryImpl.java
@@ -1,10 +1,11 @@
 package com.backend.allreva.module.recruitment.survey.infra;
 
+import static com.backend.allreva.module.recruitment.survey.domain.QSurvey.survey;
+import static com.backend.allreva.module.recruitment.survey.domain.participant.QSurveyParticipant.surveyParticipant;
+
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveyThumbnail;
 import com.backend.allreva.module.recruitment.survey.application.port.SurveySearchRepository;
-import com.backend.allreva.module.recruitment.survey.domain.QSurvey;
-import com.backend.allreva.module.recruitment.survey.domain.participant.QSurveyParticipant;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -23,8 +24,6 @@ public class SurveySearchRepositoryImpl implements SurveySearchRepository {
 
     private static final double SIMILARITY_THRESHOLD = 0.1;
     private final JPAQueryFactory queryFactory;
-    private final QSurvey survey = QSurvey.survey;
-    private final QSurveyParticipant surveyParticipant = QSurveyParticipant.surveyParticipant;
 
     @Override
     public List<SurveyThumbnail> findThumbnailsByTitle(final String title, final int limit) {


### PR DESCRIPTION
## 작업 내용

콘서트·공연장 조회에 Caffeine 로컬 캐시 도입. 데이터가 일 1회/월 1회 sync로만 변경되므로
TTL + sync 시점 @CacheEvict 조합으로 일관성 관리.
Rent/Survey는 참가자 수 실시간성 필요 + 멀티 인스턴스 불일치 위험으로 제외.

## 구현

- 캐시 매니저 단일화, 캐시별 TTL/maxSize 개별 설정, 통계 수집 활성화
- 콘서트 메인·검색·연관 조회, 공연장 단건 조회에 @Cacheable 적용
- 캐시 키는 SimpleKeyGenerator 기본값 사용 (파라미터 튜플)
- 콘서트 sync 시 concertRelated 포함 evict, 공연장 sync 시 concertHall evict
- prod 제외 환경에서 sync 수동 트리거 테스트 API 추가

## 테스트

로컬 bootRun 후 curl로 캐시 미스/히트 비교 (서버 측 duration_ms 기준)

| 엔드포인트 | 미스 | 히트 |
|-----------|------|------|
| `GET /api/v1/concerts/main` | 132ms | 2ms |
| `GET /api/v1/concerts/search` | 57ms | 1ms |
| `GET /api/v1/concerts` (related) | 23ms | 1ms |

Closes #42