### PR TITLE
[#62] HTTP 쿼리 파라미터 로그 추가

### DIFF
--- a/src/main/java/com/backend/allreva/common/logging/HttpLogFilter.java
+++ b/src/main/java/com/backend/allreva/common/logging/HttpLogFilter.java
@@ -61,13 +61,23 @@ public class HttpLogFilter extends OncePerRequestFilter {
             String duration = String.valueOf(stopWatch.getTotalTimeMillis());
             String clientIp = getClientIp(request);
 
+            String queryString = requestWrapper.getQueryString();
+
             MDC.put("method", method);
             MDC.put("uri", uri);
+            MDC.put("query_string", queryString != null ? queryString : "");
             MDC.put("status", status);
             MDC.put("duration_ms", duration);
             MDC.put("client_ip", clientIp);
 
-            log.info("HTTP {} {} → {} ({}ms) ip={}", method, uri, status, duration, clientIp);
+            log.info(
+                    "HTTP {} {}{}  → {} ({}ms) ip={}",
+                    method,
+                    uri,
+                    queryString != null ? "?" + queryString : "",
+                    status,
+                    duration,
+                    clientIp);
 
             responseWrapper.copyBodyToResponse();
             MDC.clear();

--- a/src/main/java/com/backend/allreva/common/logging/HttpLogFilter.java
+++ b/src/main/java/com/backend/allreva/common/logging/HttpLogFilter.java
@@ -30,6 +30,7 @@ public class HttpLogFilter extends OncePerRequestFilter {
     private static final AntPathMatcher pathMatcher = new AntPathMatcher();
     private static final ArrayList<String> loggingExcludeUrls =
             new ArrayList<>(List.of("/actuator/**", "/swagger/**", "/swagger-ui/**", "/api-docs/**", "/favicon.ico"));
+    private static final List<String> queryStringExcludeUrls = List.of("/api/v1/auth/**");
 
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) throws ServletException {
@@ -61,17 +62,21 @@ public class HttpLogFilter extends OncePerRequestFilter {
             String duration = String.valueOf(stopWatch.getTotalTimeMillis());
             String clientIp = getClientIp(request);
 
-            String queryString = requestWrapper.getQueryString();
+            boolean excludeQueryString = queryStringExcludeUrls.stream()
+                    .anyMatch(pattern -> pathMatcher.match(pattern, uri));
+            String queryString = excludeQueryString ? null : requestWrapper.getQueryString();
 
             MDC.put("method", method);
             MDC.put("uri", uri);
-            MDC.put("query_string", queryString != null ? queryString : "");
+            if (queryString != null) {
+                MDC.put("query_string", queryString);
+            }
             MDC.put("status", status);
             MDC.put("duration_ms", duration);
             MDC.put("client_ip", clientIp);
 
             log.info(
-                    "HTTP {} {}{}  → {} ({}ms) ip={}",
+                    "HTTP {} {}{} → {} ({}ms) ip={}",
                     method,
                     uri,
                     queryString != null ? "?" + queryString : "",

--- a/src/main/java/com/backend/allreva/common/logging/HttpLogFilter.java
+++ b/src/main/java/com/backend/allreva/common/logging/HttpLogFilter.java
@@ -62,8 +62,8 @@ public class HttpLogFilter extends OncePerRequestFilter {
             String duration = String.valueOf(stopWatch.getTotalTimeMillis());
             String clientIp = getClientIp(request);
 
-            boolean excludeQueryString = queryStringExcludeUrls.stream()
-                    .anyMatch(pattern -> pathMatcher.match(pattern, uri));
+            boolean excludeQueryString =
+                    queryStringExcludeUrls.stream().anyMatch(pattern -> pathMatcher.match(pattern, uri));
             String queryString = excludeQueryString ? null : requestWrapper.getQueryString();
 
             MDC.put("method", method);

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -9,7 +9,7 @@
     <!-- ==================== Console Appender ==================== -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan(%logger{0}) [%X{correlationId}] [%X{user_id}] %X{method} %X{uri} %X{status} %X{duration_ms}ms ip=%X{client_ip} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan(%logger{0}) [%X{correlationId}] [%X{user_id}] %X{method} %X{uri} %X{query_string} %X{status} %X{duration_ms}ms ip=%X{client_ip} - %msg%n</pattern>
             <charset>UTF-8</charset>
         </encoder>
     </appender>
@@ -19,7 +19,7 @@
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>logs/application.log</file>
             <encoder>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{0} [%X{correlationId}] [%X{user_id}] %X{method} %X{uri} %X{status} %X{duration_ms}ms ip=%X{client_ip} - %msg%n</pattern>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{0} [%X{correlationId}] [%X{user_id}] %X{method} %X{uri} %X{query_string} %X{status} %X{duration_ms}ms ip=%X{client_ip} - %msg%n</pattern>
                 <charset>UTF-8</charset>
             </encoder>
             <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
@@ -51,6 +51,7 @@
                           "user_id": "%X{user_id:-}",
                           "method": "%X{method:-}",
                           "uri": "%X{uri:-}",
+                          "query_string": "%X{query_string:-}",
                           "status": "%X{status:-}",
                           "duration_ms": "%X{duration_ms:-}",
                           "client_ip": "%X{client_ip:-}",


### PR DESCRIPTION
## 작업 내용

검색 API 호출 시 keyword, sortDirection 같은 파라미터가 로그에 안 찍혀서
요청 파악이 어려웠습니다. query_string을 MDC에 추가했습니다.

## 구현

- `HttpLogFilter`에 query_string MDC 등록 추가
- logback 패턴(console/file/JSON)에 query_string 필드 추가

## 테스트

로컬에서 logback 단위 테스트 통과

Closes #62