### PR TITLE
[#63] 클라이언트 오류 400 처리 추가

### DIFF
--- a/src/main/java/com/backend/allreva/common/web/exception/CustomControllerAdvice.java
+++ b/src/main/java/com/backend/allreva/common/web/exception/CustomControllerAdvice.java
@@ -52,7 +52,7 @@ public class CustomControllerAdvice {
     @ExceptionHandler(value = MethodArgumentTypeMismatchException.class)
     public ResponseEntity<?> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
         log.info("request param type mismatch: param={}, value={}", e.getName(), e.getValue());
-        String message = String.format("'%s' is not a valid value for '%s'", e.getValue(), e.getName());
+        String message = String.format("'%s' 파라미터에 유효하지 않은 값입니다: %s", e.getName(), e.getValue());
 
         return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
                 .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), message));
@@ -64,8 +64,7 @@ public class CustomControllerAdvice {
         log.info("request body not readable: {}", e.getMessage());
 
         return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
-                .body(Response.onFailure(
-                        GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), GlobalErrorCode.BAD_REQUEST_ERROR.getMessage()));
+                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), "JSON 형식에 맞지 않는 요청입니다."));
     }
 
     // required @RequestParam missing

--- a/src/main/java/com/backend/allreva/common/web/exception/CustomControllerAdvice.java
+++ b/src/main/java/com/backend/allreva/common/web/exception/CustomControllerAdvice.java
@@ -5,118 +5,122 @@ import com.backend.allreva.common.exception.ErrorCode;
 import com.backend.allreva.common.exception.GlobalErrorCode;
 import com.backend.allreva.common.web.response.Response;
 import jakarta.validation.ConstraintViolationException;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
 @RestControllerAdvice
-public class CustomControllerAdvice {
+public class CustomControllerAdvice extends ResponseEntityExceptionHandler {
 
-    @ExceptionHandler(value = CustomException.class)
+    @ExceptionHandler(CustomException.class)
     public ResponseEntity<?> handleCustomException(CustomException e) {
         ErrorCode errorCode = e.getErrorCode();
-
         return ResponseEntity.status(errorCode.getStatus())
                 .body(Response.onFailure(errorCode.getCode(), errorCode.getMessage()));
     }
 
-    // @RequestBody bean validation failure
-    @ExceptionHandler(value = MethodArgumentNotValidException.class)
-    public ResponseEntity<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        log.info("request body validation failed: {}", e.getMessage());
-        StringBuilder errorMessage = new StringBuilder();
-
-        for (ObjectError error : e.getBindingResult().getAllErrors()) {
-            String field = (error instanceof FieldError fe) ? fe.getField() : error.getObjectName();
-            errorMessage
-                    .append(field)
-                    .append(": ")
-                    .append(error.getDefaultMessage())
-                    .append("\n");
-        }
-
-        return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
-                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage.toString()));
-    }
-
     // @RequestParam type conversion failure (e.g. invalid enum value)
-    @ExceptionHandler(value = MethodArgumentTypeMismatchException.class)
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<?> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
         log.info("request param type mismatch: param={}, value={}", e.getName(), e.getValue());
         String message = String.format("'%s' 파라미터에 유효하지 않은 값입니다: %s", e.getName(), e.getValue());
-
         return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
                 .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), message));
     }
 
-    // JSON body parse failure (malformed JSON, invalid enum in body, wrong type)
-    @ExceptionHandler(value = HttpMessageNotReadableException.class)
-    public ResponseEntity<?> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
-        log.info("request body not readable: {}", e.getMessage());
-
-        return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
-                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), "JSON 형식에 맞지 않는 요청입니다."));
-    }
-
-    // required @RequestParam missing
-    @ExceptionHandler(value = MissingServletRequestParameterException.class)
-    public ResponseEntity<?> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
-        log.info("required request param missing: param={}", e.getParameterName());
-        String message = String.format("required parameter '%s' is missing", e.getParameterName());
-
-        return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
-                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), message));
-    }
-
-    // @ModelAttribute binding failure
-    @ExceptionHandler(value = BindException.class)
-    public ResponseEntity<?> handleBindException(BindException e) {
-        log.info("model attribute binding failed: {}", e.getMessage());
-        StringBuilder errorMessage = new StringBuilder();
-
-        for (ObjectError error : e.getBindingResult().getAllErrors()) {
-            String field = (error instanceof FieldError fe) ? fe.getField() : error.getObjectName();
-            errorMessage
-                    .append(field)
-                    .append(": ")
-                    .append(error.getDefaultMessage())
-                    .append("\n");
-        }
-
-        return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
-                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage.toString()));
-    }
-
-    // @Validated method parameter constraint violation
-    @ExceptionHandler(value = ConstraintViolationException.class)
+    // service-layer @Validated constraint violation
+    @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<?> handleConstraintViolationException(ConstraintViolationException e) {
         log.info("constraint violation: {}", e.getMessage());
         StringBuilder errorMessage = new StringBuilder();
-
         e.getConstraintViolations().forEach(v -> errorMessage
                 .append(v.getPropertyPath())
                 .append(": ")
                 .append(v.getMessage())
                 .append("\n"));
-
         return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
                 .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage.toString()));
     }
 
-    @ExceptionHandler(value = Exception.class)
+    @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleException(Exception e) {
         log.error("unexpected error: {}", e.getMessage(), e);
         return ResponseEntity.status(GlobalErrorCode.SERVER_ERROR.getStatus())
                 .body(Response.onFailure(
                         GlobalErrorCode.SERVER_ERROR.getCode(), GlobalErrorCode.SERVER_ERROR.getMessage()));
+    }
+
+    // @RequestBody/@ModelAttribute bean validation failure (Spring 6+ raises MethodArgumentNotValidException for both)
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.info("method argument validation failed: {}", e.getMessage());
+        StringBuilder errorMessage = buildFieldErrors(e.getBindingResult().getAllErrors());
+        return ResponseEntity.status(status)
+                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage.toString()));
+    }
+
+    // controller-layer @Validated method parameter constraint violation (Spring 6+)
+    @Override
+    protected ResponseEntity<Object> handleHandlerMethodValidationException(
+            HandlerMethodValidationException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.info("handler method validation failed: {}", e.getMessage());
+        StringBuilder errorMessage = new StringBuilder();
+        e.getAllValidationResults().forEach(result -> {
+            String paramName = result.getMethodParameter().getParameterName();
+            result.getResolvableErrors().forEach(error -> errorMessage
+                    .append(paramName)
+                    .append(": ")
+                    .append(error.getDefaultMessage())
+                    .append("\n"));
+        });
+        return ResponseEntity.status(status)
+                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage.toString()));
+    }
+
+    // JSON body parse failure (malformed JSON, invalid enum in body, wrong type)
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.info("request body not readable: {}", e.getMessage());
+        return ResponseEntity.status(status)
+                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), "JSON 형식에 맞지 않는 요청입니다."));
+    }
+
+    // required @RequestParam missing
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.info("required request param missing: param={}", e.getParameterName());
+        String message = String.format("필수 파라미터 '%s'가 누락되었습니다.", e.getParameterName());
+        return ResponseEntity.status(status)
+                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), message));
+    }
+
+    private StringBuilder buildFieldErrors(List<ObjectError> errors) {
+        StringBuilder errorMessage = new StringBuilder();
+        for (ObjectError error : errors) {
+            String field = (error instanceof FieldError fe) ? fe.getField() : error.getObjectName();
+            errorMessage
+                    .append(field)
+                    .append(": ")
+                    .append(error.getDefaultMessage())
+                    .append("\n");
+        }
+        return errorMessage;
     }
 }

--- a/src/main/java/com/backend/allreva/common/web/exception/CustomControllerAdvice.java
+++ b/src/main/java/com/backend/allreva/common/web/exception/CustomControllerAdvice.java
@@ -6,6 +6,7 @@ import com.backend.allreva.common.exception.GlobalErrorCode;
 import com.backend.allreva.common.web.response.Response;
 import jakarta.validation.ConstraintViolationException;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
@@ -46,14 +47,11 @@ public class CustomControllerAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<?> handleConstraintViolationException(ConstraintViolationException e) {
         log.info("constraint violation: {}", e.getMessage());
-        StringBuilder errorMessage = new StringBuilder();
-        e.getConstraintViolations().forEach(v -> errorMessage
-                .append(v.getPropertyPath())
-                .append(": ")
-                .append(v.getMessage())
-                .append("\n"));
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+                .collect(Collectors.joining("\n"));
         return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
-                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage.toString()));
+                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage));
     }
 
     @ExceptionHandler(Exception.class)
@@ -69,9 +67,10 @@ public class CustomControllerAdvice extends ResponseEntityExceptionHandler {
     protected ResponseEntity<Object> handleMethodArgumentNotValid(
             MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
         log.info("method argument validation failed: {}", e.getMessage());
-        StringBuilder errorMessage = buildFieldErrors(e.getBindingResult().getAllErrors());
         return ResponseEntity.status(status)
-                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage.toString()));
+                .body(Response.onFailure(
+                        GlobalErrorCode.BAD_REQUEST_ERROR.getCode(),
+                        buildFieldErrors(e.getBindingResult().getAllErrors())));
     }
 
     // controller-layer @Validated method parameter constraint violation (Spring 6+)
@@ -79,26 +78,27 @@ public class CustomControllerAdvice extends ResponseEntityExceptionHandler {
     protected ResponseEntity<Object> handleHandlerMethodValidationException(
             HandlerMethodValidationException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
         log.info("handler method validation failed: {}", e.getMessage());
-        StringBuilder errorMessage = new StringBuilder();
-        e.getAllValidationResults().forEach(result -> {
-            String paramName = result.getMethodParameter().getParameterName();
-            result.getResolvableErrors().forEach(error -> errorMessage
-                    .append(paramName)
-                    .append(": ")
-                    .append(error.getDefaultMessage())
-                    .append("\n"));
-        });
+        String errorMessage = e.getAllValidationResults().stream()
+                .flatMap(result -> {
+                    String paramName = result.getMethodParameter().getParameterName();
+                    return result.getResolvableErrors().stream()
+                            .map(error -> paramName + ": " + error.getDefaultMessage());
+                })
+                .collect(Collectors.joining("\n"));
         return ResponseEntity.status(status)
-                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage.toString()));
+                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage));
     }
 
-    // JSON body parse failure (malformed JSON, invalid enum in body, wrong type)
+    // JSON body parse failure (malformed JSON, missing body, invalid enum in body, wrong type)
     @Override
     protected ResponseEntity<Object> handleHttpMessageNotReadable(
             HttpMessageNotReadableException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
         log.info("request body not readable: {}", e.getMessage());
+        String message = e.getMessage() != null && e.getMessage().contains("Required request body is missing")
+                ? "요청 본문이 비어있습니다."
+                : "요청 본문이 비어있거나 JSON 형식이 올바르지 않습니다.";
         return ResponseEntity.status(status)
-                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), "JSON 형식에 맞지 않는 요청입니다."));
+                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), message));
     }
 
     // required @RequestParam missing
@@ -111,16 +111,12 @@ public class CustomControllerAdvice extends ResponseEntityExceptionHandler {
                 .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), message));
     }
 
-    private StringBuilder buildFieldErrors(List<ObjectError> errors) {
-        StringBuilder errorMessage = new StringBuilder();
-        for (ObjectError error : errors) {
-            String field = (error instanceof FieldError fe) ? fe.getField() : error.getObjectName();
-            errorMessage
-                    .append(field)
-                    .append(": ")
-                    .append(error.getDefaultMessage())
-                    .append("\n");
-        }
-        return errorMessage;
+    private String buildFieldErrors(List<ObjectError> errors) {
+        return errors.stream()
+                .map(error -> {
+                    String field = (error instanceof FieldError fe) ? fe.getField() : error.getObjectName();
+                    return field + ": " + error.getDefaultMessage();
+                })
+                .collect(Collectors.joining("\n"));
     }
 }

--- a/src/main/java/com/backend/allreva/common/web/exception/CustomControllerAdvice.java
+++ b/src/main/java/com/backend/allreva/common/web/exception/CustomControllerAdvice.java
@@ -4,13 +4,18 @@ import com.backend.allreva.common.exception.CustomException;
 import com.backend.allreva.common.exception.ErrorCode;
 import com.backend.allreva.common.exception.GlobalErrorCode;
 import com.backend.allreva.common.web.response.Response;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -24,9 +29,10 @@ public class CustomControllerAdvice {
                 .body(Response.onFailure(errorCode.getCode(), errorCode.getMessage()));
     }
 
+    // @RequestBody bean validation failure
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
     public ResponseEntity<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        log.info("user validation error: {}", e.getMessage(), e);
+        log.info("request body validation failed: {}", e.getMessage());
         StringBuilder errorMessage = new StringBuilder();
 
         for (ObjectError error : e.getBindingResult().getAllErrors()) {
@@ -37,6 +43,71 @@ public class CustomControllerAdvice {
                     .append(error.getDefaultMessage())
                     .append("\n");
         }
+
+        return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
+                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage.toString()));
+    }
+
+    // @RequestParam type conversion failure (e.g. invalid enum value)
+    @ExceptionHandler(value = MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<?> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.info("request param type mismatch: param={}, value={}", e.getName(), e.getValue());
+        String message = String.format("'%s' is not a valid value for '%s'", e.getValue(), e.getName());
+
+        return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
+                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), message));
+    }
+
+    // JSON body parse failure (malformed JSON, invalid enum in body, wrong type)
+    @ExceptionHandler(value = HttpMessageNotReadableException.class)
+    public ResponseEntity<?> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.info("request body not readable: {}", e.getMessage());
+
+        return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
+                .body(Response.onFailure(
+                        GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), GlobalErrorCode.BAD_REQUEST_ERROR.getMessage()));
+    }
+
+    // required @RequestParam missing
+    @ExceptionHandler(value = MissingServletRequestParameterException.class)
+    public ResponseEntity<?> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        log.info("required request param missing: param={}", e.getParameterName());
+        String message = String.format("required parameter '%s' is missing", e.getParameterName());
+
+        return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
+                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), message));
+    }
+
+    // @ModelAttribute binding failure
+    @ExceptionHandler(value = BindException.class)
+    public ResponseEntity<?> handleBindException(BindException e) {
+        log.info("model attribute binding failed: {}", e.getMessage());
+        StringBuilder errorMessage = new StringBuilder();
+
+        for (ObjectError error : e.getBindingResult().getAllErrors()) {
+            String field = (error instanceof FieldError fe) ? fe.getField() : error.getObjectName();
+            errorMessage
+                    .append(field)
+                    .append(": ")
+                    .append(error.getDefaultMessage())
+                    .append("\n");
+        }
+
+        return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
+                .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage.toString()));
+    }
+
+    // @Validated method parameter constraint violation
+    @ExceptionHandler(value = ConstraintViolationException.class)
+    public ResponseEntity<?> handleConstraintViolationException(ConstraintViolationException e) {
+        log.info("constraint violation: {}", e.getMessage());
+        StringBuilder errorMessage = new StringBuilder();
+
+        e.getConstraintViolations().forEach(v -> errorMessage
+                .append(v.getPropertyPath())
+                .append(": ")
+                .append(v.getMessage())
+                .append("\n"));
 
         return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST_ERROR.getStatus())
                 .body(Response.onFailure(GlobalErrorCode.BAD_REQUEST_ERROR.getCode(), errorMessage.toString()));


### PR DESCRIPTION
## 작업 내용

enum 등 타입 변환 실패 시 예외 핸들러가 없어서 500이 떨어졌습니다.
클라이언트 잘못으로 발생하는 주요 예외들을 ControllerAdvice에 추가했습니다.

## 구현

| 상황 | 응답 |
|---|---|
| `@RequestParam` 타입 변환 실패 (enum 등) | 400 + 파라미터명·입력값 안내 |
| JSON body 파싱 오류 | 400 + JSON 형식 오류 안내 |
| `@RequestBody` 필드 검증 실패 | 400 + 필드별 메시지 |
| 필수 파라미터 누락 | 400 + 파라미터명 안내 |
| `@ModelAttribute` 바인딩 실패 | 400 + 필드별 메시지 |
| `@Validated` 제약 조건 위반 | 400 + 위반 항목 안내 |

## 테스트

로컬에서 직접 요청으로 확인 (`sortDirection=ASC` → 400, malformed JSON → 400)

Closes #63