### PR TITLE
[#66] PR·이슈 제목 lint GitHub Actions 워크플로우 추가

### DIFF
--- a/.github/workflows/issue-title-lint.yml
+++ b/.github/workflows/issue-title-lint.yml
@@ -12,7 +12,8 @@ jobs:
         env:
           TITLE: ${{ github.event.issue.title }}
         run: |
-          if [[ ! "$TITLE" =~ ^\[(FEAT|BUG|DOCS|REFACTOR|TEST|PERF|CHORE|HOTFIX|CI)\]\ [^ ].* ]]; then
+          PATTERN='^\[(FEAT|BUG|DOCS|REFACTOR|TEST|PERF|CHORE|HOTFIX|CI)\] [^ ].*'
+          if [[ ! "$TITLE" =~ $PATTERN ]]; then
             echo "❌ 이슈 제목 형식이 올바르지 않습니다."
             echo "   형식: [TYPE] 설명"
             echo "   허용 타입: FEAT, BUG, DOCS, REFACTOR, TEST, PERF, CHORE, HOTFIX, CI"

--- a/.github/workflows/issue-title-lint.yml
+++ b/.github/workflows/issue-title-lint.yml
@@ -1,0 +1,23 @@
+name: Issue Title Lint
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check issue title format
+        env:
+          TITLE: ${{ github.event.issue.title }}
+        run: |
+          if [[ ! "$TITLE" =~ ^\[(FEAT|BUG|DOCS|REFACTOR|TEST|PERF|CHORE|HOTFIX|CI)\]\ [^ ].* ]]; then
+            echo "❌ 이슈 제목 형식이 올바르지 않습니다."
+            echo "   형식: [TYPE] 설명"
+            echo "   허용 타입: FEAT, BUG, DOCS, REFACTOR, TEST, PERF, CHORE, HOTFIX, CI"
+            echo "   예시: [FEAT] 차 대절 예약 시 PostgreSQL Advisory Lock으로 동시성 제어"
+            echo "   현재: $TITLE"
+            exit 1
+          fi
+          echo "✅ 이슈 제목 형식이 올바릅니다: $TITLE"

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -12,7 +12,8 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [[ ! "$TITLE" =~ ^\[#[0-9]+\]\ [^ ].* ]]; then
+          PATTERN='^\[#[0-9]+\] [^ ].*'
+          if [[ ! "$TITLE" =~ $PATTERN ]]; then
             echo "❌ PR 제목 형식이 올바르지 않습니다."
             echo "   형식: [#이슈번호] 설명"
             echo "   예시: [#66] PR 제목 lint GitHub Actions 검사 추가"

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,22 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title format
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ ! "$TITLE" =~ ^\[#[0-9]+\]\ [^ ].* ]]; then
+            echo "❌ PR 제목 형식이 올바르지 않습니다."
+            echo "   형식: [#이슈번호] 설명"
+            echo "   예시: [#66] PR 제목 lint GitHub Actions 검사 추가"
+            echo "   현재: $TITLE"
+            exit 1
+          fi
+          echo "✅ PR 제목 형식이 올바릅니다: $TITLE"


### PR DESCRIPTION
## 작업 내용

PR 제목과 이슈 제목이 컨벤션을 벗어나도 걸러낼 방법이 없었습니다.
PR 제목은 스쿼시 머지 시 커밋 메시지가 되므로 git log 품질에 직결됩니다.

## 구현

- `pr-title-lint.yml`: PR opened/edited/synchronize/reopened 시 `[#이슈번호] 설명` 형식 검사
- `issue-title-lint.yml`: 이슈 opened/edited 시 `[TYPE] 설명` 형식 검사 (허용 타입: FEAT, BUG, DOCS, REFACTOR, TEST, PERF, CHORE, HOTFIX, CI)
- 공백 2칸 이상 거부 (`[^ ].*` 패턴으로 첫 문자 비공백 강제)
- GitHub 레이블 `🚑 hotfix`, `⚙️ ci` 추가

## 테스트

로컬 bash에서 정규식 케이스 검증 (유효/무효 제목 모두 통과)

Closes #66