### PR TITLE
[#70] Cloudflare tunnel 토큰 GitHub Secrets 자동 주입

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -77,10 +77,14 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build Docker image
-        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/${APP_NAME}:latest .
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: docker build -t $DOCKERHUB_USERNAME/${APP_NAME}:latest .
 
       - name: Push to DockerHub
-        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${APP_NAME}:latest
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: docker push $DOCKERHUB_USERNAME/${APP_NAME}:latest
 
   deploy-app:
     needs: cd
@@ -97,7 +101,9 @@ jobs:
           chmod +x ~/deploy/deploy.sh
 
       - name: Blue-Green deploy
-        run: ~/deploy/deploy.sh ${APP_NAME} ${{ secrets.DOCKERHUB_USERNAME }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: ~/deploy/deploy.sh ${APP_NAME} $DOCKERHUB_USERNAME
 
       - name: Output active slot
         id: slot
@@ -115,6 +121,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Sync nginx config
+        env:
+          TUNNEL_TOKEN: ${{ secrets.TUNNEL_TOKEN }}
         run: |
           mkdir -p ~/nginx/conf.d
           cp infra/nginx.conf ~/nginx/nginx.conf
@@ -122,7 +130,7 @@ jobs:
           cp infra/docker-compose.yml ~/nginx/docker-compose.yml
           cp infra/switch.sh ~/nginx/switch.sh
           chmod +x ~/nginx/switch.sh
-          echo "TUNNEL_TOKEN=${{ secrets.TUNNEL_TOKEN }}" > ~/nginx/.env
+          echo "TUNNEL_TOKEN=$TUNNEL_TOKEN" > ~/nginx/.env
 
       - name: Switch Nginx upstream
         run: ~/nginx/switch.sh ${{ needs.deploy-app.outputs.active-slot }}

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -122,6 +122,7 @@ jobs:
           cp infra/docker-compose.yml ~/nginx/docker-compose.yml
           cp infra/switch.sh ~/nginx/switch.sh
           chmod +x ~/nginx/switch.sh
+          echo "TUNNEL_TOKEN=${{ secrets.TUNNEL_TOKEN }}" > ~/nginx/.env
 
       - name: Switch Nginx upstream
         run: ~/nginx/switch.sh ${{ needs.deploy-app.outputs.active-slot }}


### PR DESCRIPTION
## 작업 내용

서버에서 수동으로 관리하던 TUNNEL_TOKEN을 GitHub Secrets로 이전했습니다.
배포 시마다 switch-nginx job에서 ~/nginx/.env에 자동으로 주입됩니다.

## 구현

- `switch-nginx` Sync nginx config 단계에 `.env` 자동 생성 추가

## 테스트

N/A

Closes #70