### PR TITLE
[#77] Gradle 멀티모듈 뼈대와 설정 파일 구조 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,14 @@ out/
 /.nb-gradle/
 
 ### Profile-specific configs & secrets ###
-**/application-*.yml*
+**/application-dev.yml
+**/application-prod.yml
+**/application-stag.yml
+**/application-local.yml
+**/application-*-dev.yml
+**/application-*-prod.yml
+**/application-*-stag.yml
+**/application-*-local.yml
 **/.env
 
 ### VS Code ###

--- a/apps/batch-server/build.gradle
+++ b/apps/batch-server/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'org.springframework.boot'
+}
+
+dependencies {
+    implementation project(':modules:allreva-application')
+    implementation project(':modules:allreva-domain')
+    implementation project(':modules:allreva-infra')
+    implementation project(':modules:allreva-events')
+
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.flywaydb:flyway-database-postgresql'
+    runtimeOnly 'org.postgresql:postgresql'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}

--- a/apps/batch-server/src/main/java/com/backend/allreva/batch/BatchServerApplication.java
+++ b/apps/batch-server/src/main/java/com/backend/allreva/batch/BatchServerApplication.java
@@ -1,0 +1,12 @@
+package com.backend.allreva.batch;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BatchServerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BatchServerApplication.class, args);
+    }
+}

--- a/apps/batch-server/src/main/resources/application.yml
+++ b/apps/batch-server/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  application:
+    name: allreva-batch
+  profiles:
+    active: dev
+  config:
+    import:
+      - classpath:application-infra.yml
+      - optional:classpath:application-events.yml
+      - optional:classpath:application-infra-${spring.profiles.active}.yml
+      - optional:classpath:application-events-${spring.profiles.active}.yml
+      - optional:secret

--- a/apps/implement-server/build.gradle
+++ b/apps/implement-server/build.gradle
@@ -1,0 +1,130 @@
+plugins {
+    id 'org.springframework.boot'
+    id 'com.diffplug.spotless'
+    id 'org.openrewrite.rewrite'
+}
+
+dependencies {
+    implementation project(':modules:allreva-implement')
+    implementation project(':modules:allreva-application')
+    implementation project(':modules:allreva-domain')
+    implementation project(':modules:allreva-infra')
+    implementation project(':modules:allreva-events')
+
+    // web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // openfeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.3'
+    implementation 'org.springframework.cloud:spring-cloud-commons:4.1.4'
+
+    // jackson - xml
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    // database
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'io.github.openfeign.querydsl:querydsl-core:7.1'
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa:7.1'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:7.1:jpa'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    runtimeOnly 'org.postgresql:postgresql'
+
+    // flyway
+    implementation 'org.flywaydb:flyway-database-postgresql'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'it.ozimov:embedded-redis:0.7.2'
+
+    // firebase
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
+
+    // aws s3
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:${awspringVersion}")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+
+    // csv
+    implementation 'com.opencsv:opencsv:5.8'
+
+    // micrometer
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // loki log appender
+    implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
+
+    // lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // test
+    testImplementation 'org.instancio:instancio-junit:5.5.1'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:4.1.4'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'org.testcontainers:localstack'
+
+    // cache
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
+    // lint
+    rewrite platform('org.openrewrite.recipe:rewrite-recipe-bom:latest.release')
+    rewrite 'org.openrewrite.recipe:rewrite-rewrite'
+}
+
+def querydslDir = "build/generated/sources/annotationProcessor/java/main"
+
+sourceSets {
+    main {
+        java.srcDirs = ['../../src/main/java', querydslDir]
+        resources.srcDirs = ['../../src/main/resources', 'src/main/resources']
+    }
+    test {
+        java.srcDirs = ['../../src/test/java']
+        resources.srcDirs = ['../../src/test/resources']
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
+}
+
+spotless {
+    java {
+        target '../../src/main/java/**/*.java', '../../src/test/java/**/*.java', 'src/main/java/**/*.java', 'src/test/java/**/*.java'
+
+        removeUnusedImports()
+        palantirJavaFormat()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
+rewrite {
+    activeRecipe 'org.openrewrite.java.recipes.RecipeTestingBestPractices'
+    setExportDatatables true
+}

--- a/apps/implement-server/src/main/resources/application.yml
+++ b/apps/implement-server/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  application:
+    name: allreva-implement
+  profiles:
+    active: dev
+  config:
+    import:
+      - classpath:application-implement.yml
+      - classpath:application-infra.yml
+      - optional:classpath:application-events.yml
+      - optional:classpath:application-implement-${spring.profiles.active}.yml
+      - optional:classpath:application-infra-${spring.profiles.active}.yml
+      - optional:classpath:application-events-${spring.profiles.active}.yml
+      - optional:secret

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-    id 'java'
-    id 'org.springframework.boot' version '3.3.5'
-    id 'io.spring.dependency-management' version '1.1.6'
-    id "com.diffplug.spotless" version "8.2.1"
-    id "org.openrewrite.rewrite" version "7.29.0"
+    id 'base'
+    id 'org.springframework.boot' version '3.3.5' apply false
+    id 'io.spring.dependency-management' version '1.1.6' apply false
+    id 'com.diffplug.spotless' version '8.2.1' apply false
+    id 'org.openrewrite.rewrite' version '7.29.0' apply false
 }
 
 group = 'com.backend'
@@ -14,142 +14,40 @@ ext {
     set 'awspringVersion', '3.0.3'
 }
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+allprojects {
+    group = rootProject.group
+    version = rootProject.version
+
+    repositories {
+        mavenCentral()
     }
 }
 
-tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs << '-parameters'
-}
+subprojects {
+    apply plugin: 'java'
+    apply plugin: 'io.spring.dependency-management'
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-}
-
-configurations.all {
-    exclude group: 'commons-logging', module: 'commons-logging'
-}
-
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    // web
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-
-    // openfeign
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.3'
-    implementation 'org.springframework.cloud:spring-cloud-commons:4.1.4'
-
-    // jackson - xml
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
-
-    // swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
-
-    // security
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    testImplementation 'org.springframework.security:spring-security-test'
-
-    // jwt
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
-
-    // database
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation("io.github.openfeign.querydsl:querydsl-core:7.1")
-    implementation("io.github.openfeign.querydsl:querydsl-jpa:7.1")
-    annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:7.1:jpa")
-    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-    runtimeOnly 'org.postgresql:postgresql'
-
-    // flyway
-    implementation 'org.flywaydb:flyway-database-postgresql'
-
-    // redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'it.ozimov:embedded-redis:0.7.2'
-
-    // firebase
-    implementation 'com.google.firebase:firebase-admin:9.3.0'
-
-    // aws s3
-    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:${awspringVersion}")
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
-
-    // csv
-    implementation 'com.opencsv:opencsv:5.8'
-
-    // micrometer
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'io.micrometer:micrometer-registry-prometheus'
-
-    // loki log appender
-    implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
-
-    // lombok
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-    testCompileOnly 'org.projectlombok:lombok'
-    testAnnotationProcessor 'org.projectlombok:lombok'
-
-    // test
-    testImplementation 'org.instancio:instancio-junit:5.5.1'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:4.1.4'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-    testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.testcontainers:postgresql'
-    testImplementation 'org.testcontainers:localstack'
-
-    // cache
-    implementation 'com.github.ben-manes.caffeine:caffeine'
-
-    // lint
-    rewrite platform('org.openrewrite.recipe:rewrite-recipe-bom:latest.release')
-    rewrite 'org.openrewrite.recipe:rewrite-rewrite'
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
-}
-
-def querydslDir = "build/generated/sources/annotationProcessor/java/main"
-
-sourceSets {
-    main.java.srcDirs += [ querydslDir ]
-}
-
-tasks.withType(JavaCompile) {
-    options.generatedSourceOutputDirectory = file(querydslDir)
-}
-
-clean.doLast {
-    file(querydslDir).deleteDir()
-}
-
-spotless {
     java {
-        target 'src/main/java/**/*.java', 'src/test/java/**/*.java'
-
-        removeUnusedImports() // 미사용 import 제거
-        palantirJavaFormat() // Palantir Java Format
-        trimTrailingWhitespace() // 공백 제거
-        endWithNewline() // 줄바꿈 추가
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
     }
-}
 
-rewrite {
-    activeRecipe 'org.openrewrite.java.recipes.RecipeTestingBestPractices'
-    setExportDatatables true
+    tasks.withType(JavaCompile).configureEach {
+        options.compilerArgs << '-parameters'
+    }
+
+    configurations {
+        compileOnly {
+            extendsFrom annotationProcessor
+        }
+    }
+
+    configurations.all {
+        exclude group: 'commons-logging', module: 'commons-logging'
+    }
+
+    tasks.named('test') {
+        useJUnitPlatform()
+    }
 }

--- a/modules/allreva-application/build.gradle
+++ b/modules/allreva-application/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'java-library'
+}

--- a/modules/allreva-domain/build.gradle
+++ b/modules/allreva-domain/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'java-library'
+}

--- a/modules/allreva-events/build.gradle
+++ b/modules/allreva-events/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'java-library'
+}

--- a/modules/allreva-events/src/main/resources/application-events.yml
+++ b/modules/allreva-events/src/main/resources/application-events.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    event-module: allreva-events

--- a/modules/allreva-implement/build.gradle
+++ b/modules/allreva-implement/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'java-library'
+}

--- a/modules/allreva-implement/src/main/resources/application-implement.yml
+++ b/modules/allreva-implement/src/main/resources/application-implement.yml
@@ -1,58 +1,8 @@
 spring:
-  application:
-    name: allreva
-  profiles:
-    active: dev
-  config:
-    import:
-      - optional:secret
-
-  datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/allreva}
-    username: ${SPRING_DATASOURCE_USERNAME:postgres}
-    password: ${SPRING_DATASOURCE_PASSWORD}
-    driver-class-name: org.postgresql.Driver
-    hikari:
-      keepalive-time: 30000
-
-  jpa:
-    open-in-view: false
-    hibernate:
-      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
-    properties:
-      hibernate:
-        format_sql: ${HIBERNATE_FORMAT_SQL:true}
-        show_sql: ${HIBERNATE_SHOW_SQL:false}
-
-  flyway:
-    enabled: true
-    locations: classpath:db/migration
-    baseline-on-migrate: true
-    baseline-version: 1
-    out-of-order: ${SPRING.FLYWAY.OUT-OF-ORDER:false}
-    mixed: true
-    postgresql:
-      transactional-lock: false
-
-  data:
-    redis:
-      port: ${SPRING_REDIS_PORT:6379}
-      host: ${SPRING_REDIS_HOST:localhost}
-
   servlet:
     multipart:
       max-file-size: 100MB
       max-request-size: 100MB
-
-  cloud:
-    aws:
-      s3:
-        bucket: ${AWS_S3_BUCKET:allreva-bucket}
-      credentials:
-        access-key: ${AWS_ACCESS_KEY}
-        secret-key: ${AWS_SECRET_KEY}
-      region:
-        static: ${AWS_REGION:ap-northeast-2}
 
 management:
   endpoints:
@@ -79,13 +29,13 @@ url:
 oauth2:
   kakao:
     redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:5173/auth/callback}
-    client-id: ${KAKAO_CLIENT_ID}
-    client-secret: ${KAKAO_CLIENT_SECRET}
+    client-id: ${KAKAO_CLIENT_ID:}
+    client-secret: ${KAKAO_CLIENT_SECRET:}
     api-url: https://kapi.kakao.com
     auth-url: https://kauth.kakao.com
 
 jwt:
-  secret_key: ${JWT_SECRET_KEY}
+  secret_key: ${JWT_SECRET_KEY:}
   access:
     expiration: 3600000
     header: Authorization
@@ -96,7 +46,7 @@ jwt:
 public-data:
   kopis:
     base-url: https://www.kopis.or.kr/openApi/restful
-    service-key: ${KOPIS_SERVICE_KEY}
+    service-key: ${KOPIS_SERVICE_KEY:}
 
 view:
   count:
@@ -104,8 +54,8 @@ view:
       rate: 3000
 
 fcm:
-  project-id: ${FCM_PROJECT_ID}
-  service-account-key: ${FCM_SERVICE_ACCOUNT_KEY_PATH}
+  project-id: ${FCM_PROJECT_ID:}
+  service-account-key: ${FCM_SERVICE_ACCOUNT_KEY_PATH:}
 
 thread-pool:
   task:

--- a/modules/allreva-infra/build.gradle
+++ b/modules/allreva-infra/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'java-library'
+}

--- a/modules/allreva-infra/src/main/resources/application-infra.yml
+++ b/modules/allreva-infra/src/main/resources/application-infra.yml
@@ -1,0 +1,42 @@
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/allreva}
+    username: ${SPRING_DATASOURCE_USERNAME:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD:}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      keepalive-time: 30000
+
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
+    properties:
+      hibernate:
+        format_sql: ${HIBERNATE_FORMAT_SQL:true}
+        show_sql: ${HIBERNATE_SHOW_SQL:false}
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+    baseline-version: 1
+    out-of-order: ${SPRING_FLYWAY_OUT_OF_ORDER:false}
+    mixed: true
+    postgresql:
+      transactional-lock: false
+
+  data:
+    redis:
+      host: ${SPRING_REDIS_HOST:localhost}
+      port: ${SPRING_REDIS_PORT:6379}
+
+  cloud:
+    aws:
+      s3:
+        bucket: ${AWS_S3_BUCKET:allreva-bucket}
+      credentials:
+        access-key: ${AWS_ACCESS_KEY:}
+        secret-key: ${AWS_SECRET_KEY:}
+      region:
+        static: ${AWS_REGION:ap-northeast-2}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
 rootProject.name = 'allreva'
+
+include 'apps:implement-server'
+include 'apps:batch-server'
+include 'modules:allreva-implement'
+include 'modules:allreva-application'
+include 'modules:allreva-domain'
+include 'modules:allreva-infra'
+include 'modules:allreva-events'


### PR DESCRIPTION
## 작업 내용
멀티모듈 전환 첫 단계입니다. 기존 단일 모듈 빌드를 implement-server, batch-server, layer 모듈 구조로 나눴습니다. 아직 비즈니스 코드는 옮기지 않고, 빌드와 설정 뼈대만 먼저 세웠습니다.

## 구현
- `settings.gradle`에 apps/modules 멀티모듈 구조 추가
- 루트 `build.gradle`을 공통 설정 중심으로 정리
- `apps/implement-server`, `apps/batch-server` 생성
- `modules/allreva-implement`, `allreva-application`, `allreva-domain`, `allreva-infra`, `allreva-events` 생성
- `application.yml`을 실행 모듈 진입점과 모듈별 설정 파일로 분리
- profile별 dev 설정 파일은 gitignore 처리

## 테스트
- `./gradlew :apps:implement-server:compileJava :apps:batch-server:compileJava`
- `./gradlew spotlessApply spotlessCheck`

Closes #77
