### PR TITLE
[#79] rent command query 서비스 분리

### DIFF
--- a/src/main/java/com/backend/allreva/module/recruitment/rent/application/command/RentCommandService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/application/command/RentCommandService.java
@@ -1,30 +1,15 @@
-package com.backend.allreva.module.recruitment.rent.application;
+package com.backend.allreva.module.recruitment.rent.application.command;
 
-import com.backend.allreva.common.event.Events;
-import com.backend.allreva.common.event.KeywordSearchedEvent;
 import com.backend.allreva.common.exception.CustomException;
-import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.common.storage.upload.StorageUploadService;
-import com.backend.allreva.module.concert.concert.domain.Concert;
-import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
-import com.backend.allreva.module.concert.place.domain.ConcertHall;
-import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
 import com.backend.allreva.module.notification.domain.event.NotificationEvent;
 import com.backend.allreva.module.notification.domain.value.NotificationType;
-import com.backend.allreva.module.recruitment.rent.application.dto.HostedRentSummaryResponse;
-import com.backend.allreva.module.recruitment.rent.application.dto.JoinedRentResponse;
-import com.backend.allreva.module.recruitment.rent.application.dto.RentDetailResponse;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentIdRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinIdRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinUpdateRequest;
-import com.backend.allreva.module.recruitment.rent.application.dto.RentParticipantResponse;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentRegisterRequest;
-import com.backend.allreva.module.recruitment.rent.application.dto.RentSummaryResponse;
-import com.backend.allreva.module.recruitment.rent.application.dto.RentThumbnail;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentUpdateRequest;
-import com.backend.allreva.module.recruitment.rent.application.dto.SortType;
-import com.backend.allreva.module.recruitment.rent.application.port.RentSearchRepository;
 import com.backend.allreva.module.recruitment.rent.domain.Rent;
 import com.backend.allreva.module.recruitment.rent.domain.RentBoardingSlot;
 import com.backend.allreva.module.recruitment.rent.domain.RentBoardingSlotRepository;
@@ -34,70 +19,27 @@ import com.backend.allreva.module.recruitment.rent.domain.participant.RentPartic
 import com.backend.allreva.module.recruitment.rent.domain.value.Bus;
 import com.backend.allreva.module.recruitment.rent.domain.value.Depositor;
 import com.backend.allreva.module.recruitment.rent.exception.RentErrorCode;
-import com.backend.allreva.module.search.exception.SearchErrorCode;
-import java.time.LocalDate;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 
 @Slf4j
 @Service
+@Validated
 @RequiredArgsConstructor
-public class RentService {
+public class RentCommandService {
 
     private final RentRepository rentRepository;
     private final RentBoardingSlotRepository rentBoardingSlotRepository;
     private final RentParticipantRepository rentParticipantRepository;
-    private final ConcertRepository concertRepository;
-    private final ConcertHallRepository concertHallRepository;
     private final StorageUploadService storageUploadService;
-    private final RentSearchRepository rentSearchRepository;
 
-    public List<RentThumbnail> getRentSuggestions(final String title) {
-        Events.raise(new KeywordSearchedEvent(title));
-        List<RentThumbnail> thumbnails = rentSearchRepository.findThumbnailsByTitle(title, 2);
-        if (thumbnails.isEmpty()) {
-            throw new CustomException(SearchErrorCode.SEARCH_RESULT_NOT_FOUND);
-        }
-        return thumbnails;
-    }
-
-    public SliceResponse<RentThumbnail, Long> searchRents(final String title, final Long cursorId, final int size) {
-        SliceResponse<RentThumbnail, Long> response = rentSearchRepository.findAllByTitle(title, cursorId, size);
-        if (response.items().isEmpty()) {
-            throw new CustomException(SearchErrorCode.SEARCH_RESULT_NOT_FOUND);
-        }
-        return response;
-    }
-
-    // Anonymous
-    @Transactional(readOnly = true)
-    public List<RentSummaryResponse> getRentSummaries(
-            final String region,
-            final SortType sortType,
-            final LocalDate lastEndDate,
-            final Long lastId,
-            final int pageSize) {
-        return rentRepository.findAll(region, sortType, lastEndDate, lastId, pageSize).stream()
-                .map(RentSummaryResponse::from)
-                .toList();
-    }
-
-    @Transactional(readOnly = true)
-    public RentDetailResponse getRentDetail(final Long id) {
-        Rent rent = rentRepository.findById(id).orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
-        Concert concert = concertRepository.findById(rent.getConcertCode()).orElse(null);
-        ConcertHall concertHall = concert != null
-                ? concertHallRepository.findById(concert.getHallCode()).orElse(null)
-                : null;
-        return RentDetailResponse.from(rent, concert, concertHall);
-    }
-
-    // Host
     @Transactional
-    public Long registerRent(final RentRegisterRequest request, final Long memberId) {
+    public Long registerRent(@Valid final RentRegisterRequest request, final Long memberId) {
         Rent rent = request.toEntity(memberId);
         request.rentBoardingDateRequests()
                 .forEach(date -> rent.addBoardingSlot(RentBoardingSlot.builder()
@@ -106,7 +48,7 @@ public class RentService {
                         .build()));
         Rent savedRent = rentRepository.save(rent);
 
-        Events.raise(NotificationEvent.builder()
+        com.backend.allreva.common.event.Events.raise(NotificationEvent.builder()
                 .type(NotificationType.RENT_REGISTERED)
                 .recipientIds(List.of(memberId))
                 .senderId(memberId)
@@ -119,7 +61,7 @@ public class RentService {
     }
 
     @Transactional
-    public void updateRent(final RentUpdateRequest request, final Long memberId) {
+    public void updateRent(@Valid final RentUpdateRequest request, final Long memberId) {
         Rent rent = rentRepository
                 .findById(request.rentId())
                 .orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
@@ -151,7 +93,7 @@ public class RentService {
     }
 
     @Transactional
-    public void closeRent(final RentIdRequest request, final Long memberId) {
+    public void closeRent(@Valid final RentIdRequest request, final Long memberId) {
         Rent rent = rentRepository
                 .findById(request.rentId())
                 .orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
@@ -161,7 +103,7 @@ public class RentService {
     }
 
     @Transactional
-    public void deleteRent(final RentIdRequest request, final Long memberId) {
+    public void deleteRent(@Valid final RentIdRequest request, final Long memberId) {
         Rent rent = rentRepository
                 .findById(request.rentId())
                 .orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
@@ -172,33 +114,8 @@ public class RentService {
         rentRepository.delete(rent);
     }
 
-    @Transactional(readOnly = true)
-    public List<HostedRentSummaryResponse> getRentHostSummaries(
-            final Long memberId, final Long lastId, final int pageSize) {
-        return rentRepository.findAllByMemberId(memberId, lastId, pageSize).stream()
-                .map(HostedRentSummaryResponse::from)
-                .toList();
-    }
-
-    @Transactional(readOnly = true)
-    public List<RentParticipantResponse> getRentHostDetail(
-            final Long memberId, final LocalDate boardingDate, final Long rentId) {
-        Rent rent = rentRepository
-                .findByIdAndMemberId(rentId, memberId)
-                .orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
-        rent.getBoardingSlots().stream()
-                .filter(s -> s.getDate().equals(boardingDate))
-                .findFirst()
-                .orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
-
-        return rentParticipantRepository.findAllByRentIdAndBoardingDate(rentId, boardingDate).stream()
-                .map(RentParticipantResponse::from)
-                .toList();
-    }
-
-    // Participant
     @Transactional
-    public Long joinRent(final RentJoinRequest request, final Long memberId) {
+    public Long joinRent(@Valid final RentJoinRequest request, final Long memberId) {
         if (rentParticipantRepository.exists(memberId, request.rentId(), request.boardingDate())) {
             throw new CustomException(RentErrorCode.RENT_JOIN_ALREADY_EXISTS);
         }
@@ -218,7 +135,7 @@ public class RentService {
     }
 
     @Transactional
-    public void updateRentJoin(final RentJoinUpdateRequest request, final Long memberId) {
+    public void updateRentJoin(@Valid final RentJoinUpdateRequest request, final Long memberId) {
         RentParticipant participant = rentParticipantRepository
                 .findById(request.rentParticipantId())
                 .orElseThrow(() -> new CustomException(RentErrorCode.RENT_JOIN_NOT_FOUND));
@@ -238,7 +155,7 @@ public class RentService {
     }
 
     @Transactional
-    public void cancelRentJoin(final RentJoinIdRequest request, final Long memberId) {
+    public void cancelRentJoin(@Valid final RentJoinIdRequest request, final Long memberId) {
         RentParticipant participant = rentParticipantRepository
                 .findById(request.rentParticipantId())
                 .orElseThrow(() -> new CustomException(RentErrorCode.RENT_JOIN_NOT_FOUND));
@@ -256,30 +173,5 @@ public class RentService {
         }
 
         rentParticipantRepository.delete(participant);
-    }
-
-    @Transactional(readOnly = true)
-    public List<JoinedRentResponse> getJoinedRentSummaries(final Long memberId, final Long lastId, final int pageSize) {
-        List<RentParticipant> participants = rentParticipantRepository.findAllByMemberId(memberId, lastId, pageSize);
-
-        return participants.stream()
-                .map(participant -> {
-                    Rent rent = participant.getRent();
-                    RentBoardingSlot slot = rent.getBoardingSlots().stream()
-                            .filter(s -> s.getDate().equals(participant.getBoardingDate()))
-                            .findFirst()
-                            .orElse(null);
-                    return JoinedRentResponse.from(participant, rent, slot);
-                })
-                .toList();
-    }
-
-    @Transactional(readOnly = true)
-    public RentParticipantResponse getJoinedRentDetail(
-            final Long memberId, final LocalDate boardingDate, final Long rentId) {
-        return rentParticipantRepository
-                .findByMemberIdAndBoardingDateAndRentId(memberId, boardingDate, rentId)
-                .map(RentParticipantResponse::from)
-                .orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/application/query/RentQueryService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/application/query/RentQueryService.java
@@ -1,0 +1,125 @@
+package com.backend.allreva.module.recruitment.rent.application.query;
+
+import com.backend.allreva.common.event.Events;
+import com.backend.allreva.common.event.KeywordSearchedEvent;
+import com.backend.allreva.common.exception.CustomException;
+import com.backend.allreva.common.pagination.SliceResponse;
+import com.backend.allreva.module.concert.concert.domain.Concert;
+import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
+import com.backend.allreva.module.concert.place.domain.ConcertHall;
+import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
+import com.backend.allreva.module.recruitment.rent.application.dto.HostedRentSummaryResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.JoinedRentResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentDetailResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentParticipantResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentSummaryResponse;
+import com.backend.allreva.module.recruitment.rent.application.dto.RentThumbnail;
+import com.backend.allreva.module.recruitment.rent.application.dto.SortType;
+import com.backend.allreva.module.recruitment.rent.application.port.RentSearchRepository;
+import com.backend.allreva.module.recruitment.rent.domain.Rent;
+import com.backend.allreva.module.recruitment.rent.domain.RentRepository;
+import com.backend.allreva.module.recruitment.rent.domain.participant.RentParticipant;
+import com.backend.allreva.module.recruitment.rent.domain.participant.RentParticipantRepository;
+import com.backend.allreva.module.recruitment.rent.exception.RentErrorCode;
+import com.backend.allreva.module.search.exception.SearchErrorCode;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RentQueryService {
+
+    private final RentRepository rentRepository;
+    private final RentParticipantRepository rentParticipantRepository;
+    private final ConcertRepository concertRepository;
+    private final ConcertHallRepository concertHallRepository;
+    private final RentSearchRepository rentSearchRepository;
+
+    public List<RentThumbnail> getRentSuggestions(final String title) {
+        Events.raise(new KeywordSearchedEvent(title));
+        List<RentThumbnail> thumbnails = rentSearchRepository.findThumbnailsByTitle(title, 2);
+        if (thumbnails.isEmpty()) {
+            throw new CustomException(SearchErrorCode.SEARCH_RESULT_NOT_FOUND);
+        }
+        return thumbnails;
+    }
+
+    public SliceResponse<RentThumbnail, Long> searchRents(final String title, final Long cursorId, final int size) {
+        SliceResponse<RentThumbnail, Long> response = rentSearchRepository.findAllByTitle(title, cursorId, size);
+        if (response.items().isEmpty()) {
+            throw new CustomException(SearchErrorCode.SEARCH_RESULT_NOT_FOUND);
+        }
+        return response;
+    }
+
+    public List<RentSummaryResponse> getRentSummaries(
+            final String region,
+            final SortType sortType,
+            final LocalDate lastEndDate,
+            final Long lastId,
+            final int pageSize) {
+        return rentRepository.findAll(region, sortType, lastEndDate, lastId, pageSize).stream()
+                .map(RentSummaryResponse::from)
+                .toList();
+    }
+
+    public RentDetailResponse getRentDetail(final Long id) {
+        Rent rent = rentRepository.findById(id).orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
+        Concert concert = concertRepository.findById(rent.getConcertCode()).orElse(null);
+        ConcertHall concertHall = concert != null
+                ? concertHallRepository.findById(concert.getHallCode()).orElse(null)
+                : null;
+        return RentDetailResponse.from(rent, concert, concertHall);
+    }
+
+    public List<HostedRentSummaryResponse> getRentHostSummaries(
+            final Long memberId, final Long lastId, final int pageSize) {
+        return rentRepository.findAllByMemberId(memberId, lastId, pageSize).stream()
+                .map(HostedRentSummaryResponse::from)
+                .toList();
+    }
+
+    public List<RentParticipantResponse> getRentHostDetail(
+            final Long memberId, final LocalDate boardingDate, final Long rentId) {
+        Rent rent = rentRepository
+                .findByIdAndMemberId(rentId, memberId)
+                .orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
+        rent.getBoardingSlots().stream()
+                .filter(s -> s.getDate().equals(boardingDate))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
+
+        return rentParticipantRepository.findAllByRentIdAndBoardingDate(rentId, boardingDate).stream()
+                .map(RentParticipantResponse::from)
+                .toList();
+    }
+
+    public List<JoinedRentResponse> getJoinedRentSummaries(final Long memberId, final Long lastId, final int pageSize) {
+        List<RentParticipant> participants = rentParticipantRepository.findAllByMemberId(memberId, lastId, pageSize);
+
+        return participants.stream()
+                .map(participant -> {
+                    Rent rent = participant.getRent();
+                    return JoinedRentResponse.from(
+                            participant,
+                            rent,
+                            rent.getBoardingSlots().stream()
+                                    .filter(s -> s.getDate().equals(participant.getBoardingDate()))
+                                    .findFirst()
+                                    .orElse(null));
+                })
+                .toList();
+    }
+
+    public RentParticipantResponse getJoinedRentDetail(
+            final Long memberId, final LocalDate boardingDate, final Long rentId) {
+        return rentParticipantRepository
+                .findByMemberIdAndBoardingDateAndRentId(memberId, boardingDate, rentId)
+                .map(RentParticipantResponse::from)
+                .orElseThrow(() -> new CustomException(RentErrorCode.RENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentController.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/presentation/RentController.java
@@ -4,7 +4,8 @@ import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.auth.security.AuthMember;
 import com.backend.allreva.module.member.domain.Member;
-import com.backend.allreva.module.recruitment.rent.application.RentService;
+import com.backend.allreva.module.recruitment.rent.application.command.RentCommandService;
+import com.backend.allreva.module.recruitment.rent.application.query.RentQueryService;
 import com.backend.allreva.module.recruitment.rent.application.dto.HostedRentSummaryResponse;
 import com.backend.allreva.module.recruitment.rent.application.dto.JoinedRentResponse;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentDetailResponse;
@@ -38,12 +39,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/rents")
 public class RentController implements RentControllerSwagger {
 
-    private final RentService rentService;
+    private final RentCommandService rentCommandService;
+    private final RentQueryService rentQueryService;
 
     @Override
     @GetMapping("/suggestions")
     public Response<List<RentThumbnail>> getRentSuggestions(@RequestParam final String query) {
-        return Response.onSuccess(rentService.getRentSuggestions(query));
+        return Response.onSuccess(rentQueryService.getRentSuggestions(query));
     }
 
     @Override
@@ -52,7 +54,7 @@ public class RentController implements RentControllerSwagger {
             @RequestParam final String query,
             @RequestParam(defaultValue = "7") final int pageSize,
             @RequestParam(required = false) final Long cursorId) {
-        return Response.onSuccess(rentService.searchRents(query, cursorId, pageSize));
+        return Response.onSuccess(rentQueryService.searchRents(query, cursorId, pageSize));
     }
 
     // Anonymous EndPoints
@@ -64,13 +66,13 @@ public class RentController implements RentControllerSwagger {
             @RequestParam(name = "lastId", required = false) final Long lastId,
             @RequestParam(name = "lastEndDate", required = false) final LocalDate lastEndDate,
             @RequestParam(name = "pageSize", defaultValue = "10") final int pageSize) {
-        return Response.onSuccess(rentService.getRentSummaries(region, sortType, lastEndDate, lastId, pageSize));
+        return Response.onSuccess(rentQueryService.getRentSummaries(region, sortType, lastEndDate, lastId, pageSize));
     }
 
     @Override
     @GetMapping("/{id}")
     public Response<RentDetailResponse> getRentDetail(@PathVariable final Long id) {
-        return Response.onSuccess(rentService.getRentDetail(id));
+        return Response.onSuccess(rentQueryService.getRentDetail(id));
     }
 
     // Host Endpoints
@@ -78,7 +80,7 @@ public class RentController implements RentControllerSwagger {
     @PostMapping
     public Response<Long> registerRent(
             @RequestBody final RentRegisterRequest rentRegisterRequest, @AuthMember final Member member) {
-        Long rentId = rentService.registerRent(rentRegisterRequest, member.getId());
+        Long rentId = rentCommandService.registerRent(rentRegisterRequest, member.getId());
         return Response.onSuccess(rentId);
     }
 
@@ -86,21 +88,21 @@ public class RentController implements RentControllerSwagger {
     @PatchMapping
     public Response<Void> updateRent(
             @RequestBody final RentUpdateRequest rentUpdateRequest, @AuthMember final Member member) {
-        rentService.updateRent(rentUpdateRequest, member.getId());
+        rentCommandService.updateRent(rentUpdateRequest, member.getId());
         return Response.onSuccess();
     }
 
     @Override
     @PatchMapping("/close")
     public Response<Void> closeRent(@RequestBody final RentIdRequest rentIdRequest, @AuthMember final Member member) {
-        rentService.closeRent(rentIdRequest, member.getId());
+        rentCommandService.closeRent(rentIdRequest, member.getId());
         return Response.onSuccess();
     }
 
     @Override
     @DeleteMapping
     public Response<Void> deleteRent(@RequestBody final RentIdRequest rentIdRequest, @AuthMember final Member member) {
-        rentService.deleteRent(rentIdRequest, member.getId());
+        rentCommandService.deleteRent(rentIdRequest, member.getId());
         return Response.onSuccess();
     }
 
@@ -110,7 +112,7 @@ public class RentController implements RentControllerSwagger {
             @AuthMember Member member,
             @RequestParam(name = "lastId", required = false) final Long lastId,
             @RequestParam(name = "pageSize", defaultValue = "10") final int pageSize) {
-        return Response.onSuccess(rentService.getRentHostSummaries(member.getId(), lastId, pageSize));
+        return Response.onSuccess(rentQueryService.getRentHostSummaries(member.getId(), lastId, pageSize));
     }
 
     @Override
@@ -119,7 +121,7 @@ public class RentController implements RentControllerSwagger {
             @PathVariable("id") final Long rentId,
             @RequestParam final LocalDate boardingDate,
             @AuthMember Member member) {
-        return Response.onSuccess(rentService.getRentHostDetail(member.getId(), boardingDate, rentId));
+        return Response.onSuccess(rentQueryService.getRentHostDetail(member.getId(), boardingDate, rentId));
     }
 
     // Participant Endpoints
@@ -127,7 +129,7 @@ public class RentController implements RentControllerSwagger {
     @PostMapping("/join")
     public Response<Long> joinRent(
             @RequestBody final RentJoinRequest rentJoinRequest, @AuthMember final Member member) {
-        Long participantId = rentService.joinRent(rentJoinRequest, member.getId());
+        Long participantId = rentCommandService.joinRent(rentJoinRequest, member.getId());
         return Response.onSuccess(participantId);
     }
 
@@ -135,7 +137,7 @@ public class RentController implements RentControllerSwagger {
     @PatchMapping("/join")
     public Response<Void> updateRentJoin(
             @RequestBody final RentJoinUpdateRequest rentJoinUpdateRequest, @AuthMember final Member member) {
-        rentService.updateRentJoin(rentJoinUpdateRequest, member.getId());
+        rentCommandService.updateRentJoin(rentJoinUpdateRequest, member.getId());
         return Response.onSuccess();
     }
 
@@ -143,7 +145,7 @@ public class RentController implements RentControllerSwagger {
     @DeleteMapping("/join")
     public Response<Void> cancelRentJoin(
             @RequestBody final RentJoinIdRequest rentJoinIdRequest, @AuthMember final Member member) {
-        rentService.cancelRentJoin(rentJoinIdRequest, member.getId());
+        rentCommandService.cancelRentJoin(rentJoinIdRequest, member.getId());
         return Response.onSuccess();
     }
 
@@ -153,7 +155,7 @@ public class RentController implements RentControllerSwagger {
             @AuthMember final Member member,
             @RequestParam(name = "lastId", required = false) final Long lastId,
             @RequestParam(name = "pageSize", defaultValue = "10") final int pageSize) {
-        return Response.onSuccess(rentService.getJoinedRentSummaries(member.getId(), lastId, pageSize));
+        return Response.onSuccess(rentQueryService.getJoinedRentSummaries(member.getId(), lastId, pageSize));
     }
 
     @Override
@@ -162,6 +164,6 @@ public class RentController implements RentControllerSwagger {
             @PathVariable("id") final Long rentId,
             @RequestParam final LocalDate boardingDate,
             @AuthMember Member member) {
-        return Response.onSuccess(rentService.getJoinedRentDetail(member.getId(), boardingDate, rentId));
+        return Response.onSuccess(rentQueryService.getJoinedRentDetail(member.getId(), boardingDate, rentId));
     }
 }

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentCommandIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentCommandIntegrationTest.java
@@ -14,7 +14,7 @@ import com.backend.allreva.module.concert.concert.infra.jpa.ConcertJpaRepository
 import com.backend.allreva.module.member.domain.Member;
 import com.backend.allreva.module.member.domain.MemberRepository;
 import com.backend.allreva.module.member.fixture.MemberFixture;
-import com.backend.allreva.module.recruitment.rent.application.RentService;
+import com.backend.allreva.module.recruitment.rent.application.command.RentCommandService;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentIdRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinIdRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinRequest;
@@ -44,7 +44,7 @@ class RentCommandIntegrationTest extends IntegrationTestSupport {
     private static final List<LocalDate> BOARDING_DATES = List.of(LocalDate.of(2030, 12, 1), LocalDate.of(2030, 12, 2));
 
     @Autowired
-    private RentService rentService;
+    private RentCommandService rentService;
 
     @Autowired
     private RentRepository rentRepository;

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentConcurrencyTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentConcurrencyTest.java
@@ -13,7 +13,7 @@ import com.backend.allreva.module.concert.concert.infra.jpa.ConcertJpaRepository
 import com.backend.allreva.module.member.domain.Member;
 import com.backend.allreva.module.member.domain.MemberRepository;
 import com.backend.allreva.module.member.fixture.MemberFixture;
-import com.backend.allreva.module.recruitment.rent.application.RentService;
+import com.backend.allreva.module.recruitment.rent.application.command.RentCommandService;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentJoinRequest;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentRegisterRequest;
 import com.backend.allreva.module.recruitment.rent.fixture.RentFixture;
@@ -43,7 +43,7 @@ class RentConcurrencyTest extends IntegrationTestSupport {
     private static final LocalDate BOARDING_DATE = LocalDate.of(2030, 12, 1);
 
     @Autowired
-    private RentService rentService;
+    private RentCommandService rentCommandService;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -76,7 +76,7 @@ class RentConcurrencyTest extends IntegrationTestSupport {
 
         Concert concert = concertJpaRepository.save(
                 Instancio.of(ConcertFixture.inProgressConcertModel()).create());
-        rentId = rentService.registerRent(
+        rentId = rentCommandService.registerRent(
                 Instancio.of(RentFixture.rentRegisterRequestModel())
                         .set(field(RentRegisterRequest.class, "concertCode"), concert.getConcertCode())
                         .set(field(RentRegisterRequest.class, "rentBoardingDateRequests"), List.of(BOARDING_DATE))
@@ -114,7 +114,7 @@ class RentConcurrencyTest extends IntegrationTestSupport {
                 ready.countDown();
                 try {
                     start.await();
-                    rentService.joinRent(
+                    rentCommandService.joinRent(
                             Instancio.of(RentFixture.rentJoinRequestModel())
                                     .set(field(RentJoinRequest.class, "rentId"), rentId)
                                     .set(field(RentJoinRequest.class, "boardingDate"), BOARDING_DATE)

--- a/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentQueryIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/rent/integration/RentQueryIntegrationTest.java
@@ -13,7 +13,8 @@ import com.backend.allreva.module.concert.concert.infra.jpa.ConcertJpaRepository
 import com.backend.allreva.module.member.domain.Member;
 import com.backend.allreva.module.member.domain.MemberRepository;
 import com.backend.allreva.module.member.fixture.MemberFixture;
-import com.backend.allreva.module.recruitment.rent.application.RentService;
+import com.backend.allreva.module.recruitment.rent.application.command.RentCommandService;
+import com.backend.allreva.module.recruitment.rent.application.query.RentQueryService;
 import com.backend.allreva.module.recruitment.rent.application.dto.HostedRentSummaryResponse;
 import com.backend.allreva.module.recruitment.rent.application.dto.JoinedRentResponse;
 import com.backend.allreva.module.recruitment.rent.application.dto.RentDetailResponse;
@@ -50,7 +51,10 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             List.of(LocalDate.of(2030, 12, 1), LocalDate.of(2030, 12, 2), LocalDate.of(2030, 12, 3));
 
     @Autowired
-    private RentService rentService;
+    private RentQueryService rentService;
+
+    @Autowired
+    private RentCommandService rentCommandService;
 
     @Autowired
     private RentJpaRepository rentJpaRepository;
@@ -111,7 +115,7 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedRentId = rentService.registerRent(buildRegisterRequest(), savedMember.getId());
+            savedRentId = rentCommandService.registerRent(buildRegisterRequest(), savedMember.getId());
         }
 
         @Nested
@@ -155,7 +159,7 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @BeforeEach
             void setUp() {
                 for (int i = 0; i < 15; i++) {
-                    rentService.registerRent(buildRegisterRequest(), savedMember.getId());
+                    rentCommandService.registerRent(buildRegisterRequest(), savedMember.getId());
                 }
             }
 
@@ -175,7 +179,7 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
                 // given
                 List<RentSummaryResponse> all = rentService.getRentSummaries(null, SortType.LATEST, null, null, 15);
                 Long firstRentId = all.get(0).rentId();
-                rentService.closeRent(
+                rentCommandService.closeRent(
                         Instancio.of(RentFixture.rentIdRequestModel())
                                 .set(field(RentIdRequest.class, "rentId"), firstRentId)
                                 .create(),
@@ -221,11 +225,11 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             @BeforeEach
             void setUp() {
                 for (int i = 0; i < 15; i++) {
-                    rentService.registerRent(buildRegisterRequest(), savedMember.getId());
+                    rentCommandService.registerRent(buildRegisterRequest(), savedMember.getId());
                 }
                 otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
                 for (int i = 0; i < 5; i++) {
-                    rentService.registerRent(buildRegisterRequest(), otherMember.getId());
+                    rentCommandService.registerRent(buildRegisterRequest(), otherMember.getId());
                 }
             }
 
@@ -295,7 +299,7 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedRentId = rentService.registerRent(buildRegisterRequest(), savedMember.getId());
+            savedRentId = rentCommandService.registerRent(buildRegisterRequest(), savedMember.getId());
         }
 
         @Nested
@@ -306,8 +310,8 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             void setUp() {
                 Member member2 = memberRepository.save(MemberFixture.createTestMemberWithIndex(2));
                 Member member3 = memberRepository.save(MemberFixture.createTestMemberWithIndex(3));
-                rentService.joinRent(buildJoinRequest(savedRentId, TARGET_DATE, 1), member2.getId());
-                rentService.joinRent(buildJoinRequest(savedRentId, TARGET_DATE, 1), member3.getId());
+                rentCommandService.joinRent(buildJoinRequest(savedRentId, TARGET_DATE, 1), member2.getId());
+                rentCommandService.joinRent(buildJoinRequest(savedRentId, TARGET_DATE, 1), member3.getId());
             }
 
             @Test
@@ -386,12 +390,12 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
             savedRegisterRequest = buildRegisterRequest();
 
             for (int i = 0; i < 5; i++) {
-                Long rentId = rentService.registerRent(savedRegisterRequest, savedMember.getId());
+                Long rentId = rentCommandService.registerRent(savedRegisterRequest, savedMember.getId());
                 rentIds.add(rentId);
 
                 for (LocalDate date : SLOT_DATES) {
-                    rentService.joinRent(buildJoinRequest(rentId, date, 1), savedMember.getId());
-                    rentService.joinRent(buildJoinRequest(rentId, date, 1), otherMember.getId());
+                    rentCommandService.joinRent(buildJoinRequest(rentId, date, 1), savedMember.getId());
+                    rentCommandService.joinRent(buildJoinRequest(rentId, date, 1), otherMember.getId());
                 }
             }
         }
@@ -479,9 +483,9 @@ class RentQueryIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedRentId = rentService.registerRent(buildRegisterRequest(), savedMember.getId());
+            savedRentId = rentCommandService.registerRent(buildRegisterRequest(), savedMember.getId());
             savedJoinRequest = buildJoinRequest(savedRentId, TARGET_DATE, 2);
-            rentService.joinRent(savedJoinRequest, savedMember.getId());
+            rentCommandService.joinRent(savedJoinRequest, savedMember.getId());
         }
 
         @Nested


### PR DESCRIPTION
## 작업 내용
rent 파일럿에서 조회와 상태 변경 책임을 먼저 나눴습니다. 기존 `RentService` 하나에 섞여 있던 메서드를 command/query 서비스로 분리하고, 컨트롤러와 통합 테스트도 새 구조를 따라가도록 정리했습니다.

## 구현
- `RentService`를 `RentCommandService`, `RentQueryService`로 분리
- `RentController`가 command/query 서비스를 각각 주입하도록 변경
- command 통합 테스트는 `RentCommandService` 기준으로 정리
- query 통합 테스트는 `RentQueryService`와 `RentCommandService`를 함께 사용하도록 정리
- 동시성 테스트가 command 서비스 기준으로 동작하도록 수정

## 테스트
- `./gradlew :apps:api-server:compileJava :apps:api-server:compileTestJava`
- `./gradlew :apps:api-server:test --tests '*RentCommandIntegrationTest' --tests '*RentQueryIntegrationTest' --tests '*RentConcurrencyTest'`
- `./gradlew spotlessApply spotlessCheck`

Closes #79
