### PR TITLE
[#81] 공통 이벤트 패키지와 검색 이벤트 위치 분리

### DIFF
--- a/src/main/java/com/backend/allreva/events/Event.java
+++ b/src/main/java/com/backend/allreva/events/Event.java
@@ -1,4 +1,4 @@
-package com.backend.allreva.common.event;
+package com.backend.allreva.events;
 
 import lombok.Getter;
 

--- a/src/main/java/com/backend/allreva/events/Events.java
+++ b/src/main/java/com/backend/allreva/events/Events.java
@@ -1,4 +1,4 @@
-package com.backend.allreva.common.event;
+package com.backend.allreva.events;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/backend/allreva/events/EventsConfig.java
+++ b/src/main/java/com/backend/allreva/events/EventsConfig.java
@@ -1,4 +1,4 @@
-package com.backend.allreva.common.event;
+package com.backend.allreva.events;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.InitializingBean;

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertService.java
@@ -1,7 +1,7 @@
 package com.backend.allreva.module.concert.concert.application;
 
-import com.backend.allreva.common.event.Events;
-import com.backend.allreva.common.event.KeywordSearchedEvent;
+import com.backend.allreva.events.Events;
+import com.backend.allreva.module.search.domain.event.KeywordSearchedEvent;
 import com.backend.allreva.common.exception.CustomException;
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;

--- a/src/main/java/com/backend/allreva/module/notification/domain/event/NotificationEvent.java
+++ b/src/main/java/com/backend/allreva/module/notification/domain/event/NotificationEvent.java
@@ -1,6 +1,6 @@
 package com.backend.allreva.module.notification.domain.event;
 
-import com.backend.allreva.common.event.Event;
+import com.backend.allreva.events.Event;
 import com.backend.allreva.module.notification.domain.value.NotificationType;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/com/backend/allreva/module/notification/infra/sse/event/SseTimedOutEvent.java
+++ b/src/main/java/com/backend/allreva/module/notification/infra/sse/event/SseTimedOutEvent.java
@@ -1,6 +1,6 @@
 package com.backend.allreva.module.notification.infra.sse.event;
 
-import com.backend.allreva.common.event.Event;
+import com.backend.allreva.events.Event;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/application/command/RentCommandService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/application/command/RentCommandService.java
@@ -48,7 +48,7 @@ public class RentCommandService {
                         .build()));
         Rent savedRent = rentRepository.save(rent);
 
-        com.backend.allreva.common.event.Events.raise(NotificationEvent.builder()
+        com.backend.allreva.events.Events.raise(NotificationEvent.builder()
                 .type(NotificationType.RENT_REGISTERED)
                 .recipientIds(List.of(memberId))
                 .senderId(memberId)

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/application/query/RentQueryService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/application/query/RentQueryService.java
@@ -1,7 +1,7 @@
 package com.backend.allreva.module.recruitment.rent.application.query;
 
-import com.backend.allreva.common.event.Events;
-import com.backend.allreva.common.event.KeywordSearchedEvent;
+import com.backend.allreva.events.Events;
+import com.backend.allreva.module.search.domain.event.KeywordSearchedEvent;
 import com.backend.allreva.common.exception.CustomException;
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.module.concert.concert.domain.Concert;

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/application/SurveyService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/application/SurveyService.java
@@ -1,7 +1,7 @@
 package com.backend.allreva.module.recruitment.survey.application;
 
-import com.backend.allreva.common.event.Events;
-import com.backend.allreva.common.event.KeywordSearchedEvent;
+import com.backend.allreva.events.Events;
+import com.backend.allreva.module.search.domain.event.KeywordSearchedEvent;
 import com.backend.allreva.common.exception.CustomException;
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.module.concert.concert.domain.Concert;

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/domain/participant/SurveyParticipant.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/domain/participant/SurveyParticipant.java
@@ -1,6 +1,6 @@
 package com.backend.allreva.module.recruitment.survey.domain.participant;
 
-import com.backend.allreva.common.event.Events;
+import com.backend.allreva.events.Events;
 import com.backend.allreva.common.model.BaseEntity;
 import com.backend.allreva.module.recruitment.survey.domain.value.BoardingType;
 import jakarta.persistence.Column;

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/domain/participant/SurveyParticipantEvent.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/domain/participant/SurveyParticipantEvent.java
@@ -1,6 +1,6 @@
 package com.backend.allreva.module.recruitment.survey.domain.participant;
 
-import com.backend.allreva.common.event.Event;
+import com.backend.allreva.events.Event;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/backend/allreva/module/search/application/KeywordSearchedEventListener.java
+++ b/src/main/java/com/backend/allreva/module/search/application/KeywordSearchedEventListener.java
@@ -1,6 +1,6 @@
 package com.backend.allreva.module.search.application;
 
-import com.backend.allreva.common.event.KeywordSearchedEvent;
+import com.backend.allreva.module.search.domain.event.KeywordSearchedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;

--- a/src/main/java/com/backend/allreva/module/search/domain/event/KeywordSearchedEvent.java
+++ b/src/main/java/com/backend/allreva/module/search/domain/event/KeywordSearchedEvent.java
@@ -1,5 +1,6 @@
-package com.backend.allreva.common.event;
+package com.backend.allreva.module.search.domain.event;
 
+import com.backend.allreva.events.Event;
 import lombok.Getter;
 
 @Getter

--- a/src/test/java/com/backend/allreva/module/search/integration/KeywordSearchedEventIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/search/integration/KeywordSearchedEventIntegrationTest.java
@@ -3,8 +3,8 @@ package com.backend.allreva.module.search.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import com.backend.allreva.common.event.Events;
-import com.backend.allreva.common.event.KeywordSearchedEvent;
+import com.backend.allreva.events.Events;
+import com.backend.allreva.module.search.domain.event.KeywordSearchedEvent;
 import com.backend.allreva.support.IntegrationTestSupport;
 import java.time.Duration;
 import org.junit.jupiter.api.AfterEach;


### PR DESCRIPTION
## 작업 내용
common/event에 섞여 있던 이벤트 발행 기반과 검색 키워드 이벤트를 먼저 분리했습니다. 범위를 크게 벌리지 않고, 공통 발행 인프라와 비즈니스 이벤트의 위치를 나누는 최소 단계만 적용했습니다.

## 구현
- `Event`, `Events`, `EventsConfig`를 `com.backend.allreva.events`로 이동
- `KeywordSearchedEvent`를 `module.search.domain.event`로 이동
- concert / rent / survey / search / notification 쪽 이벤트 import를 새 구조에 맞게 정리
- `NotificationEvent`, `SseTimedOutEvent`, `SurveyParticipantEvent`가 새 공통 이벤트 기반을 사용하도록 정리
- 검색 키워드 이벤트 통합 테스트 import를 새 구조에 맞게 정리

## 테스트
- `./gradlew :apps:api-server:compileJava :apps:api-server:compileTestJava`
- `./gradlew :apps:api-server:test --tests '*KeywordSearchedEventIntegrationTest' --tests '*RentQueryIntegrationTest'`
- `./gradlew spotlessApply spotlessCheck`

Closes #81
