### PR TITLE
[#82] survey command query 분리와 concert query 정리

### DIFF
--- a/src/main/java/com/backend/allreva/module/concert/concert/application/query/ConcertQueryService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/query/ConcertQueryService.java
@@ -1,9 +1,8 @@
-package com.backend.allreva.module.concert.concert.application;
+package com.backend.allreva.module.concert.concert.application.query;
 
-import com.backend.allreva.events.Events;
-import com.backend.allreva.module.search.domain.event.KeywordSearchedEvent;
 import com.backend.allreva.common.exception.CustomException;
 import com.backend.allreva.common.pagination.SliceResponse;
+import com.backend.allreva.events.Events;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertThumbnail;
 import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
@@ -14,6 +13,7 @@ import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
 import com.backend.allreva.module.concert.concert.exception.ConcertErrorCode;
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
+import com.backend.allreva.module.search.domain.event.KeywordSearchedEvent;
 import com.backend.allreva.module.search.exception.SearchErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,13 +23,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class ConcertService {
+@Transactional(readOnly = true)
+public class ConcertQueryService {
 
     private final ConcertRepository concertRepository;
     private final ConcertHallRepository concertHallRepository;
     private final ConcertSearchRepository concertSearchRepository;
 
-    @Transactional(readOnly = true)
     public List<ConcertThumbnail> getConcertSuggestions(final String title) {
         Events.raise(new KeywordSearchedEvent(title));
         List<ConcertThumbnail> thumbnails = concertSearchRepository.findThumbnailsByTitle(title, 2);
@@ -40,7 +40,6 @@ public class ConcertService {
     }
 
     @Cacheable(cacheNames = "concertSearch")
-    @Transactional(readOnly = true)
     public SliceResponse<ConcertThumbnail, String> searchConcerts(
             final String title, final String cursorCode, final int size) {
         SliceResponse<ConcertThumbnail, String> response =
@@ -52,7 +51,6 @@ public class ConcertService {
     }
 
     @Cacheable(cacheNames = "concertMain")
-    @Transactional(readOnly = true)
     public SliceResponse<ConcertThumbnail, String> getMainConcerts(
             final String address, final String cursorCode, final int size, final SortDirection sortDirection) {
         SliceResponse<ConcertThumbnail, String> response =
@@ -64,7 +62,6 @@ public class ConcertService {
     }
 
     @Cacheable(cacheNames = "concertRelated")
-    @Transactional(readOnly = true)
     public List<RelatedConcertResponse> getRelatedConcerts(
             final String hallCode, final String lastConcertCode, final int pageSize) {
         return concertRepository.findAllByHallCode(hallCode, lastConcertCode, pageSize).stream()
@@ -72,7 +69,6 @@ public class ConcertService {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
     public ConcertDetailResponse getConcertDetail(final String concertCode) {
         Concert concert = concertRepository
                 .findById(concertCode)

--- a/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertController.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertController.java
@@ -2,7 +2,7 @@ package com.backend.allreva.module.concert.concert.presentation;
 
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.common.web.response.Response;
-import com.backend.allreva.module.concert.concert.application.ConcertService;
+import com.backend.allreva.module.concert.concert.application.query.ConcertQueryService;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertThumbnail;
 import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class ConcertController implements ConcertControllerSwagger {
 
-    private final ConcertService concertService;
+    private final ConcertQueryService concertQueryService;
 
     @Override
     @GetMapping("/main")
@@ -31,13 +31,13 @@ public class ConcertController implements ConcertControllerSwagger {
             @RequestParam(defaultValue = "DATE") final SortDirection sortDirection,
             @RequestParam(defaultValue = "7") final int pageSize,
             @RequestParam(required = false) final String cursorCode) {
-        return Response.onSuccess(concertService.getMainConcerts(region, cursorCode, pageSize, sortDirection));
+        return Response.onSuccess(concertQueryService.getMainConcerts(region, cursorCode, pageSize, sortDirection));
     }
 
     @Override
     @GetMapping("/suggestions")
     public Response<List<ConcertThumbnail>> getConcertSuggestions(@RequestParam final String query) {
-        return Response.onSuccess(concertService.getConcertSuggestions(query));
+        return Response.onSuccess(concertQueryService.getConcertSuggestions(query));
     }
 
     @Override
@@ -46,13 +46,13 @@ public class ConcertController implements ConcertControllerSwagger {
             @RequestParam final String query,
             @RequestParam(defaultValue = "7") final int pageSize,
             @RequestParam(required = false) final String cursorCode) {
-        return Response.onSuccess(concertService.searchConcerts(query, cursorCode, pageSize));
+        return Response.onSuccess(concertQueryService.searchConcerts(query, cursorCode, pageSize));
     }
 
     @Override
     @GetMapping("/{concertCode}")
     public Response<ConcertDetailResponse> getConcertDetail(@PathVariable("concertCode") final String concertCode) {
-        return Response.onSuccess(concertService.getConcertDetail(concertCode));
+        return Response.onSuccess(concertQueryService.getConcertDetail(concertCode));
     }
 
     @Override
@@ -61,6 +61,6 @@ public class ConcertController implements ConcertControllerSwagger {
             @RequestParam final String hallCode,
             @RequestParam(required = false) final String lastConcertCode,
             @RequestParam(defaultValue = "3") final int pageSize) {
-        return Response.onSuccess(concertService.getRelatedConcerts(hallCode, lastConcertCode, pageSize));
+        return Response.onSuccess(concertQueryService.getRelatedConcerts(hallCode, lastConcertCode, pageSize));
     }
 }

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/application/command/SurveyCommandService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/application/command/SurveyCommandService.java
@@ -1,67 +1,34 @@
-package com.backend.allreva.module.recruitment.survey.application;
+package com.backend.allreva.module.recruitment.survey.application.command;
 
-import com.backend.allreva.events.Events;
-import com.backend.allreva.module.search.domain.event.KeywordSearchedEvent;
 import com.backend.allreva.common.exception.CustomException;
-import com.backend.allreva.common.pagination.SliceResponse;
+import com.backend.allreva.events.Events;
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
 import com.backend.allreva.module.concert.concert.exception.ConcertErrorCode;
 import com.backend.allreva.module.notification.domain.event.NotificationEvent;
 import com.backend.allreva.module.notification.domain.value.NotificationType;
-import com.backend.allreva.module.recruitment.survey.application.dto.CreatedSurveyResponse;
 import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyRequest;
-import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyResponse;
 import com.backend.allreva.module.recruitment.survey.application.dto.OpenSurveyRequest;
-import com.backend.allreva.module.recruitment.survey.application.dto.SortType;
-import com.backend.allreva.module.recruitment.survey.application.dto.SurveyDetailResponse;
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveyIdRequest;
-import com.backend.allreva.module.recruitment.survey.application.dto.SurveyMainResponse;
-import com.backend.allreva.module.recruitment.survey.application.dto.SurveySummaryResponse;
-import com.backend.allreva.module.recruitment.survey.application.dto.SurveyThumbnail;
 import com.backend.allreva.module.recruitment.survey.application.dto.UpdateSurveyRequest;
-import com.backend.allreva.module.recruitment.survey.application.port.SurveySearchRepository;
 import com.backend.allreva.module.recruitment.survey.domain.Survey;
 import com.backend.allreva.module.recruitment.survey.domain.SurveyRepository;
 import com.backend.allreva.module.recruitment.survey.domain.participant.SurveyParticipant;
 import com.backend.allreva.module.recruitment.survey.domain.participant.SurveyParticipantRepository;
-import com.backend.allreva.module.recruitment.survey.domain.value.Region;
 import com.backend.allreva.module.recruitment.survey.exception.SurveyErrorCode;
-import com.backend.allreva.module.search.exception.SearchErrorCode;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
-public class SurveyService {
+public class SurveyCommandService {
 
     private final SurveyRepository surveyRepository;
     private final SurveyParticipantRepository surveyParticipantRepository;
     private final ConcertRepository concertRepository;
-    private final SurveySearchRepository surveySearchRepository;
-
-    public List<SurveyThumbnail> getSurveySuggestions(final String title) {
-        Events.raise(new KeywordSearchedEvent(title));
-        List<SurveyThumbnail> thumbnails = surveySearchRepository.findThumbnailsByTitle(title, 2);
-        if (thumbnails.isEmpty()) {
-            throw new CustomException(SearchErrorCode.SEARCH_RESULT_NOT_FOUND);
-        }
-        return thumbnails;
-    }
-
-    public SliceResponse<SurveyThumbnail, Long> searchSurveys(final String title, final Long cursorId, final int size) {
-        SliceResponse<SurveyThumbnail, Long> response = surveySearchRepository.findAllByTitle(title, cursorId, size);
-        if (response.items().isEmpty()) {
-            throw new CustomException(SearchErrorCode.SEARCH_RESULT_NOT_FOUND);
-        }
-        return response;
-    }
 
     @Transactional
     public Long openSurvey(final Long memberId, final OpenSurveyRequest request) {
@@ -90,7 +57,6 @@ public class SurveyService {
         return survey.getId();
     }
 
-    /** 수요조사 수정 */
     @Transactional
     public void updateSurvey(final Long memberId, final UpdateSurveyRequest request) {
         Survey survey = findSurvey(request.surveyId());
@@ -107,7 +73,6 @@ public class SurveyService {
                 request.boardingDates());
     }
 
-    /** 수요조사 삭제 */
     @Transactional
     public void removeSurvey(final Long memberId, final SurveyIdRequest surveyIdRequest) {
         Survey survey = findSurvey(surveyIdRequest.surveyId());
@@ -115,7 +80,6 @@ public class SurveyService {
         surveyRepository.delete(survey);
     }
 
-    /** 수요조사 참여 (응답 제출) */
     @Transactional
     public Long joinSurvey(final Long memberId, final JoinSurveyRequest request) {
         if (surveyParticipantRepository.existsByMemberIdAndSurveyId(memberId, request.surveyId())) {
@@ -137,7 +101,6 @@ public class SurveyService {
         return surveyParticipantRepository.save(participant).getId();
     }
 
-    /** 수요조사 참여 취소 */
     @Transactional
     public void cancelJoin(final Long memberId, final Long participantId) {
         SurveyParticipant participant = surveyParticipantRepository
@@ -147,46 +110,6 @@ public class SurveyService {
             throw new CustomException(SurveyErrorCode.SURVEY_JOIN_ACCESS_DENIED);
         }
         surveyParticipantRepository.delete(participant);
-    }
-
-    /** 내가 개설한 수요조사 목록 조회 */
-    @Transactional(readOnly = true)
-    public List<CreatedSurveyResponse> findCreatedSurveyList(
-            final Long memberId, final Long lastId, final LocalDate lastBoardingDate, final int pageSize) {
-        return surveyParticipantRepository.findCreatedSurveyList(memberId, lastId, lastBoardingDate, pageSize);
-    }
-
-    /** 내가 참여한 수요조사 목록 조회 */
-    @Transactional(readOnly = true)
-    public List<JoinSurveyResponse> findJoinSurveyList(final Long memberId, final Long lastId, final int pageSize) {
-        return surveyParticipantRepository.findJoinSurveyList(memberId, lastId, pageSize);
-    }
-
-    /** 수요조사 상세 조회 */
-    @Transactional(readOnly = true)
-    public SurveyDetailResponse findSurveyDetail(final Long surveyId) {
-        return surveyRepository.findSurveyDetail(surveyId);
-    }
-
-    /** 수요조사 목록 조회 */
-    @Transactional(readOnly = true)
-    public List<SurveySummaryResponse> findSurveyList(
-            final Region region,
-            final SortType sortType,
-            final Long lastId,
-            final LocalDate lastEndDate,
-            final int pageSize) {
-        return surveyRepository.findSurveyList(region, sortType, lastId, lastEndDate, pageSize);
-    }
-
-    @Transactional(readOnly = true)
-    public Optional<SurveyMainResponse> findSurveyWithParticipationCount(final Long surveyId) {
-        return surveyRepository.findSurveyWithParticipationCount(surveyId);
-    }
-
-    @Transactional(readOnly = true)
-    public List<SurveySummaryResponse> findSurveyMainList() {
-        return surveyRepository.findSurveyMainList();
     }
 
     private void validateBoardingDates(final String concertCode, final List<LocalDate> boardingDates) {

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/application/query/SurveyQueryService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/application/query/SurveyQueryService.java
@@ -1,0 +1,81 @@
+package com.backend.allreva.module.recruitment.survey.application.query;
+
+import com.backend.allreva.common.exception.CustomException;
+import com.backend.allreva.common.pagination.SliceResponse;
+import com.backend.allreva.events.Events;
+import com.backend.allreva.module.recruitment.survey.application.dto.CreatedSurveyResponse;
+import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyResponse;
+import com.backend.allreva.module.recruitment.survey.application.dto.SortType;
+import com.backend.allreva.module.recruitment.survey.application.dto.SurveyDetailResponse;
+import com.backend.allreva.module.recruitment.survey.application.dto.SurveyMainResponse;
+import com.backend.allreva.module.recruitment.survey.application.dto.SurveySummaryResponse;
+import com.backend.allreva.module.recruitment.survey.application.dto.SurveyThumbnail;
+import com.backend.allreva.module.recruitment.survey.application.port.SurveySearchRepository;
+import com.backend.allreva.module.recruitment.survey.domain.SurveyRepository;
+import com.backend.allreva.module.recruitment.survey.domain.participant.SurveyParticipantRepository;
+import com.backend.allreva.module.recruitment.survey.domain.value.Region;
+import com.backend.allreva.module.search.domain.event.KeywordSearchedEvent;
+import com.backend.allreva.module.search.exception.SearchErrorCode;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SurveyQueryService {
+
+    private final SurveyRepository surveyRepository;
+    private final SurveyParticipantRepository surveyParticipantRepository;
+    private final SurveySearchRepository surveySearchRepository;
+
+    public List<SurveyThumbnail> getSurveySuggestions(final String title) {
+        Events.raise(new KeywordSearchedEvent(title));
+        List<SurveyThumbnail> thumbnails = surveySearchRepository.findThumbnailsByTitle(title, 2);
+        if (thumbnails.isEmpty()) {
+            throw new CustomException(SearchErrorCode.SEARCH_RESULT_NOT_FOUND);
+        }
+        return thumbnails;
+    }
+
+    public SliceResponse<SurveyThumbnail, Long> searchSurveys(final String title, final Long cursorId, final int size) {
+        SliceResponse<SurveyThumbnail, Long> response = surveySearchRepository.findAllByTitle(title, cursorId, size);
+        if (response.items().isEmpty()) {
+            throw new CustomException(SearchErrorCode.SEARCH_RESULT_NOT_FOUND);
+        }
+        return response;
+    }
+
+    public List<CreatedSurveyResponse> findCreatedSurveyList(
+            final Long memberId, final Long lastId, final LocalDate lastBoardingDate, final int pageSize) {
+        return surveyParticipantRepository.findCreatedSurveyList(memberId, lastId, lastBoardingDate, pageSize);
+    }
+
+    public List<JoinSurveyResponse> findJoinSurveyList(final Long memberId, final Long lastId, final int pageSize) {
+        return surveyParticipantRepository.findJoinSurveyList(memberId, lastId, pageSize);
+    }
+
+    public SurveyDetailResponse findSurveyDetail(final Long surveyId) {
+        return surveyRepository.findSurveyDetail(surveyId);
+    }
+
+    public List<SurveySummaryResponse> findSurveyList(
+            final Region region,
+            final SortType sortType,
+            final Long lastId,
+            final LocalDate lastEndDate,
+            final int pageSize) {
+        return surveyRepository.findSurveyList(region, sortType, lastId, lastEndDate, pageSize);
+    }
+
+    public Optional<SurveyMainResponse> findSurveyWithParticipationCount(final Long surveyId) {
+        return surveyRepository.findSurveyWithParticipationCount(surveyId);
+    }
+
+    public List<SurveySummaryResponse> findSurveyMainList() {
+        return surveyRepository.findSurveyMainList();
+    }
+}

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/presentation/SurveyController.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/presentation/SurveyController.java
@@ -5,7 +5,8 @@ import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.common.web.response.Response;
 import com.backend.allreva.module.auth.security.AuthMember;
 import com.backend.allreva.module.member.domain.Member;
-import com.backend.allreva.module.recruitment.survey.application.SurveyService;
+import com.backend.allreva.module.recruitment.survey.application.command.SurveyCommandService;
+import com.backend.allreva.module.recruitment.survey.application.query.SurveyQueryService;
 import com.backend.allreva.module.recruitment.survey.application.dto.CreatedSurveyResponse;
 import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyRequest;
 import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyResponse;
@@ -38,12 +39,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/surveys")
 public class SurveyController implements SurveyControllerSwagger {
 
-    private final SurveyService surveyService;
+    private final SurveyCommandService surveyCommandService;
+    private final SurveyQueryService surveyQueryService;
 
     @Override
     @GetMapping("/suggestions")
     public Response<List<SurveyThumbnail>> getSurveySuggestions(@RequestParam final String query) {
-        return Response.onSuccess(surveyService.getSurveySuggestions(query));
+        return Response.onSuccess(surveyQueryService.getSurveySuggestions(query));
     }
 
     @Override
@@ -52,34 +54,34 @@ public class SurveyController implements SurveyControllerSwagger {
             @RequestParam final String query,
             @RequestParam(defaultValue = "7") final int pageSize,
             @RequestParam(required = false) final Long cursorId) {
-        return Response.onSuccess(surveyService.searchSurveys(query, cursorId, pageSize));
+        return Response.onSuccess(surveyQueryService.searchSurveys(query, cursorId, pageSize));
     }
 
     @Override
     @PostMapping
     public Response<Long> openSurvey(@AuthMember Member member, @RequestBody OpenSurveyRequest openSurveyRequest) {
-        return Response.onSuccess(surveyService.openSurvey(member.getId(), openSurveyRequest));
+        return Response.onSuccess(surveyCommandService.openSurvey(member.getId(), openSurveyRequest));
     }
 
     @Override
     @PatchMapping
     public Response<Void> updateSurvey(
             @AuthMember Member member, @RequestBody UpdateSurveyRequest updateSurveyRequest) {
-        surveyService.updateSurvey(member.getId(), updateSurveyRequest);
+        surveyCommandService.updateSurvey(member.getId(), updateSurveyRequest);
         return Response.onSuccess();
     }
 
     @Override
     @DeleteMapping
     public Response<Void> removeSurvey(@AuthMember Member member, @RequestBody SurveyIdRequest surveyIdRequest) {
-        surveyService.removeSurvey(member.getId(), surveyIdRequest);
+        surveyCommandService.removeSurvey(member.getId(), surveyIdRequest);
         return Response.onSuccess();
     }
 
     @Override
     @GetMapping("/{surveyId}")
     public Response<SurveyDetailResponse> findSurveyDetail(@PathVariable(name = "surveyId") Long surveyId) {
-        return Response.onSuccess(surveyService.findSurveyDetail(surveyId));
+        return Response.onSuccess(surveyQueryService.findSurveyDetail(surveyId));
     }
 
     @Override
@@ -93,26 +95,26 @@ public class SurveyController implements SurveyControllerSwagger {
         if (lastEndDate != null && lastId == null) {
             throw new CustomException(SurveyErrorCode.SURVEY_ILLEGAL_PARAMETER);
         }
-        return Response.onSuccess(surveyService.findSurveyList(region, sortType, lastId, lastEndDate, pageSize));
+        return Response.onSuccess(surveyQueryService.findSurveyList(region, sortType, lastId, lastEndDate, pageSize));
     }
 
     @Override
     @GetMapping("/main")
     public Response<List<SurveySummaryResponse>> findSurveyMainList() {
-        return Response.onSuccess(surveyService.findSurveyMainList());
+        return Response.onSuccess(surveyQueryService.findSurveyMainList());
     }
 
     @Override
     @PostMapping("/apply")
     public Response<Long> joinSurvey(@AuthMember Member member, @RequestBody JoinSurveyRequest joinSurveyRequest) {
-        return Response.onSuccess(surveyService.joinSurvey(member.getId(), joinSurveyRequest));
+        return Response.onSuccess(surveyCommandService.joinSurvey(member.getId(), joinSurveyRequest));
     }
 
     @Override
     @DeleteMapping("/apply/{participantId}")
     public Response<Void> cancelJoin(
             @AuthMember Member member, @PathVariable(name = "participantId") Long participantId) {
-        surveyService.cancelJoin(member.getId(), participantId);
+        surveyCommandService.cancelJoin(member.getId(), participantId);
         return Response.onSuccess();
     }
 
@@ -124,7 +126,7 @@ public class SurveyController implements SurveyControllerSwagger {
             @RequestParam(name = "lastBoardingDate", required = false) final LocalDate lastBoardingDate,
             @RequestParam(value = "pageSize", defaultValue = "10") final int pageSize) {
         return Response.onSuccess(
-                surveyService.findCreatedSurveyList(member.getId(), lastId, lastBoardingDate, pageSize));
+                surveyQueryService.findCreatedSurveyList(member.getId(), lastId, lastBoardingDate, pageSize));
     }
 
     @Override
@@ -133,6 +135,6 @@ public class SurveyController implements SurveyControllerSwagger {
             @AuthMember Member member,
             @RequestParam(value = "lastSurveyParticipantId", required = false) final Long lastId,
             @RequestParam(value = "pageSize", defaultValue = "10") final int pageSize) {
-        return Response.onSuccess(surveyService.findJoinSurveyList(member.getId(), lastId, pageSize));
+        return Response.onSuccess(surveyQueryService.findJoinSurveyList(member.getId(), lastId, pageSize));
     }
 }

--- a/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertIntegrationTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.instancio.Select.field;
 
-import com.backend.allreva.module.concert.concert.application.ConcertService;
+import com.backend.allreva.module.concert.concert.application.query.ConcertQueryService;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailResponse;
 import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import com.backend.allreva.module.concert.concert.domain.Concert;
@@ -27,7 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class ConcertIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
-    private ConcertService concertService;
+    private ConcertQueryService concertService;
 
     @Autowired
     private ConcertRepository concertRepository;

--- a/src/test/java/com/backend/allreva/module/recruitment/survey/integration/SurveyIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/survey/integration/SurveyIntegrationTest.java
@@ -12,7 +12,7 @@ import com.backend.allreva.module.concert.concert.infra.jpa.ConcertJpaRepository
 import com.backend.allreva.module.member.domain.Member;
 import com.backend.allreva.module.member.domain.MemberRepository;
 import com.backend.allreva.module.member.fixture.MemberFixture;
-import com.backend.allreva.module.recruitment.survey.application.SurveyService;
+import com.backend.allreva.module.recruitment.survey.application.command.SurveyCommandService;
 import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyRequest;
 import com.backend.allreva.module.recruitment.survey.application.dto.OpenSurveyRequest;
 import com.backend.allreva.module.recruitment.survey.application.dto.SortType;
@@ -20,6 +20,7 @@ import com.backend.allreva.module.recruitment.survey.application.dto.SurveyDetai
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveyIdRequest;
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveySummaryResponse;
 import com.backend.allreva.module.recruitment.survey.application.dto.UpdateSurveyRequest;
+import com.backend.allreva.module.recruitment.survey.application.query.SurveyQueryService;
 import com.backend.allreva.module.recruitment.survey.domain.SurveyRepository;
 import com.backend.allreva.module.recruitment.survey.domain.participant.SurveyParticipantRepository;
 import com.backend.allreva.module.recruitment.survey.domain.value.Region;
@@ -44,7 +45,10 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
     private static final List<LocalDate> BOARDING_DATES = List.of(LocalDate.of(2030, 12, 1), LocalDate.of(2030, 12, 2));
 
     @Autowired
-    private SurveyService surveyService;
+    private SurveyCommandService surveyCommandService;
+
+    @Autowired
+    private SurveyQueryService surveyQueryService;
 
     @Autowired
     private SurveyRepository surveyRepository;
@@ -113,26 +117,20 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @BeforeEach
             void setUp() {
                 savedOpenRequest = buildOpenRequest();
-                savedSurveyId = surveyService.openSurvey(savedMember.getId(), savedOpenRequest);
+                savedSurveyId = surveyCommandService.openSurvey(savedMember.getId(), savedOpenRequest);
             }
 
             @Test
             @DisplayName("수요조사가 저장된다")
             void it_saves_survey() {
-                // when
                 var survey = surveyRepository.findById(savedSurveyId).orElseThrow();
-
-                // then
                 assertThat(survey.getTitle()).isEqualTo(savedOpenRequest.title());
             }
 
             @Test
             @DisplayName("탑승 날짜가 JSONB로 저장된다")
             void it_saves_boarding_dates_as_jsonb() {
-                // when
                 var survey = surveyRepository.findById(savedSurveyId).orElseThrow();
-
-                // then
                 assertThat(survey.getBoardingDates()).hasSize(2);
                 assertThat(survey.getBoardingDates()).containsAll(BOARDING_DATES);
             }
@@ -147,7 +145,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedSurveyId = surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
+            savedSurveyId = surveyCommandService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Nested
@@ -157,16 +155,13 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("수요조사가 수정된다")
             void it_updates_survey() {
-                // given
                 UpdateSurveyRequest updateRequest = Instancio.of(SurveyFixture.updateSurveyRequestModel())
                         .set(field(UpdateSurveyRequest.class, "surveyId"), savedSurveyId)
                         .set(field(UpdateSurveyRequest.class, "boardingDates"), BOARDING_DATES)
                         .create();
 
-                // when
-                surveyService.updateSurvey(savedMember.getId(), updateRequest);
+                surveyCommandService.updateSurvey(savedMember.getId(), updateRequest);
 
-                // then
                 var survey = surveyRepository.findById(savedSurveyId).orElseThrow();
                 assertThat(survey.getTitle()).isEqualTo(updateRequest.title());
             }
@@ -179,15 +174,13 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
-                // given
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
                 UpdateSurveyRequest updateRequest = Instancio.of(SurveyFixture.updateSurveyRequestModel())
                         .set(field(UpdateSurveyRequest.class, "surveyId"), savedSurveyId)
                         .set(field(UpdateSurveyRequest.class, "boardingDates"), BOARDING_DATES)
                         .create();
 
-                // when & then
-                assertThatThrownBy(() -> surveyService.updateSurvey(otherMember.getId(), updateRequest))
+                assertThatThrownBy(() -> surveyCommandService.updateSurvey(otherMember.getId(), updateRequest))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(SurveyErrorCode.SURVEY_NOT_WRITER.getMessage());
             }
@@ -202,7 +195,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedSurveyId = surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
+            savedSurveyId = surveyCommandService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Nested
@@ -212,15 +205,12 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("수요조사가 소프트 삭제된다")
             void it_soft_deletes_survey() {
-                // given
                 SurveyIdRequest idRequest = Instancio.of(SurveyFixture.surveyIdRequestModel())
                         .set(field(SurveyIdRequest.class, "surveyId"), savedSurveyId)
                         .create();
 
-                // when
-                surveyService.removeSurvey(savedMember.getId(), idRequest);
+                surveyCommandService.removeSurvey(savedMember.getId(), idRequest);
 
-                // then
                 assertThat(surveyRepository.findById(savedSurveyId)).isEmpty();
             }
         }
@@ -232,14 +222,12 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
-                // given
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
                 SurveyIdRequest idRequest = Instancio.of(SurveyFixture.surveyIdRequestModel())
                         .set(field(SurveyIdRequest.class, "surveyId"), savedSurveyId)
                         .create();
 
-                // when & then
-                assertThatThrownBy(() -> surveyService.removeSurvey(otherMember.getId(), idRequest))
+                assertThatThrownBy(() -> surveyCommandService.removeSurvey(otherMember.getId(), idRequest))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(SurveyErrorCode.SURVEY_NOT_WRITER.getMessage());
             }
@@ -255,7 +243,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedSurveyId = surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
+            savedSurveyId = surveyCommandService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Nested
@@ -265,11 +253,9 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여자가 저장된다")
             void it_saves_participant() {
-                // when
                 Long participantId =
-                        surveyService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
+                        surveyCommandService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
 
-                // then
                 assertThat(participantId).isNotNull();
             }
         }
@@ -280,14 +266,13 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
             @BeforeEach
             void setUp() {
-                surveyService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
+                surveyCommandService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
             }
 
             @Test
             @DisplayName("중복 참여 예외가 발생한다")
             void it_throws_already_exists() {
-                // when & then
-                assertThatThrownBy(() -> surveyService.joinSurvey(
+                assertThatThrownBy(() -> surveyCommandService.joinSurvey(
                                 savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE)))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(SurveyErrorCode.SURVEY_JOIN_ALREADY_EXISTS.getMessage());
@@ -304,7 +289,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedSurveyId = surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
+            savedSurveyId = surveyCommandService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Nested
@@ -314,14 +299,11 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("참여자가 삭제된다")
             void it_deletes_participant() {
-                // given
                 Long participantId =
-                        surveyService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
+                        surveyCommandService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
 
-                // when
-                surveyService.cancelJoin(savedMember.getId(), participantId);
+                surveyCommandService.cancelJoin(savedMember.getId(), participantId);
 
-                // then
                 assertThat(surveyParticipantRepository.findById(participantId)).isEmpty();
             }
         }
@@ -333,13 +315,11 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("접근 거부 예외가 발생한다")
             void it_throws_access_denied() {
-                // given
                 Long participantId =
-                        surveyService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
+                        surveyCommandService.joinSurvey(savedMember.getId(), buildJoinRequest(savedSurveyId, TARGET_DATE));
                 Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
 
-                // when & then
-                assertThatThrownBy(() -> surveyService.cancelJoin(otherMember.getId(), participantId))
+                assertThatThrownBy(() -> surveyCommandService.cancelJoin(otherMember.getId(), participantId))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(SurveyErrorCode.SURVEY_JOIN_ACCESS_DENIED.getMessage());
             }
@@ -354,7 +334,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            savedSurveyId = surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
+            savedSurveyId = surveyCommandService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Nested
@@ -364,10 +344,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("상세 정보가 반환된다")
             void it_returns_detail() {
-                // when
-                SurveyDetailResponse detail = surveyService.findSurveyDetail(savedSurveyId);
-
-                // then
+                SurveyDetailResponse detail = surveyQueryService.findSurveyDetail(savedSurveyId);
                 assertThat(detail).isNotNull();
             }
         }
@@ -379,8 +356,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("NOT_FOUND 예외가 발생한다")
             void it_throws_not_found() {
-                // when & then
-                assertThatThrownBy(() -> surveyService.findSurveyDetail(999L))
+                assertThatThrownBy(() -> surveyQueryService.findSurveyDetail(999L))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(SurveyErrorCode.SURVEY_NOT_FOUND.getMessage());
             }
@@ -393,19 +369,17 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
+            surveyCommandService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Test
         @DisplayName("지역 필터링이 동작한다")
         void it_filters_by_region() {
-            // when
             List<SurveySummaryResponse> seoulResults =
-                    surveyService.findSurveyList(Region.서울, SortType.LATEST, null, null, 10);
+                    surveyQueryService.findSurveyList(Region.서울, SortType.LATEST, null, null, 10);
             List<SurveySummaryResponse> busanResults =
-                    surveyService.findSurveyList(Region.부산, SortType.LATEST, null, null, 10);
+                    surveyQueryService.findSurveyList(Region.부산, SortType.LATEST, null, null, 10);
 
-            // then
             assertThat(seoulResults).isNotEmpty();
             assertThat(busanResults).isEmpty();
         }
@@ -413,10 +387,7 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
         @Test
         @DisplayName("최신순 정렬로 목록이 반환된다")
         void it_sorts_by_latest() {
-            // when
-            List<SurveySummaryResponse> results = surveyService.findSurveyList(null, SortType.LATEST, null, null, 10);
-
-            // then
+            List<SurveySummaryResponse> results = surveyQueryService.findSurveyList(null, SortType.LATEST, null, null, 10);
             assertThat(results).isNotEmpty();
         }
     }
@@ -427,20 +398,17 @@ class SurveyIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            surveyService.openSurvey(savedMember.getId(), buildOpenRequest());
+            surveyCommandService.openSurvey(savedMember.getId(), buildOpenRequest());
         }
 
         @Test
         @DisplayName("개설자의 수요조사 목록이 반환된다")
         void it_returns_own_surveys() {
-            // given
             Member otherMember = memberRepository.save(MemberFixture.createOtherTestMember());
 
-            // when
-            var ownSurveys = surveyService.findCreatedSurveyList(savedMember.getId(), null, null, 10);
-            var otherSurveys = surveyService.findCreatedSurveyList(otherMember.getId(), null, null, 10);
+            var ownSurveys = surveyQueryService.findCreatedSurveyList(savedMember.getId(), null, null, 10);
+            var otherSurveys = surveyQueryService.findCreatedSurveyList(otherMember.getId(), null, null, 10);
 
-            // then
             assertThat(ownSurveys).isNotEmpty();
             assertThat(otherSurveys).isEmpty();
         }


### PR DESCRIPTION
## 작업 내용
rent에서 먼저 검증한 분리 방식을 survey와 concert에도 최소 범위로 확장했습니다. survey는 command/query를 실제로 나눴고, concert는 현재 조회 중심 구조라 query 전용 서비스라는 의도를 이름으로 드러냈습니다.

## 구현
- `SurveyService`를 `SurveyCommandService`, `SurveyQueryService`로 분리
- `SurveyController`가 command/query 서비스를 각각 주입하도록 변경
- `ConcertService`를 `ConcertQueryService`로 이름 정리
- `ConcertController`가 query 전용 서비스를 사용하도록 변경
- survey/concert 통합 테스트가 새 서비스 구조를 따라가도록 수정

## 테스트
- `./gradlew :apps:api-server:compileJava :apps:api-server:compileTestJava`
- `./gradlew :apps:api-server:test --tests '*SurveyIntegrationTest' --tests '*ConcertIntegrationTest'`
- `./gradlew spotlessApply spotlessCheck`

Closes #82
