### PR TITLE
[#83] query 협력 객체 위치와 네이밍 정리

### DIFF
--- a/MODULE_PACKAGE_POLICY.md
+++ b/MODULE_PACKAGE_POLICY.md
@@ -202,6 +202,12 @@ JPA 기술 구현 세부사항이므로 `infra` 소속입니다.
 - query service는 `application/query`
 - controller query endpoint는 `implement/query`
 
+## Validation 정책
+
+- 요청 DTO 검증은 controller에만 두지 않고 application service에서도 동작하게 유지합니다.
+- command service는 `@Validated`, DTO 파라미터는 `@Valid`를 우선 적용합니다.
+- API 계층은 검증 실패를 HTTP 응답으로 변환하고, 검증 규칙 자체는 application usecase 가까이에 둡니다.
+
 ## Observability 정책
 
 - logging / metrics / tracing 공통 지원은 `allreva-observability` 후보 모듈로 관리합니다.

--- a/MODULE_PACKAGE_POLICY.md
+++ b/MODULE_PACKAGE_POLICY.md
@@ -183,8 +183,9 @@ Aggregate 저장과 상태 변경에 필요한 인터페이스만 둡니다.
 - `ConcertSearchRepository`
 
 정책:
-- query 전용 계약은 `application/.../query` 또는 `application/.../port`
-- 구현은 `infra/.../query`
+- query 전용 계약은 `application/query/port`
+- 구현은 `infra/query`
+- `*SearchRepository`처럼 조회 목적이 분명한 이름을 우선 사용
 - Aggregate 저장소와 같은 이름/역할로 섞지 않음
 
 ## 3. Spring Data JPA repository
@@ -213,8 +214,9 @@ JPA 기술 구현 세부사항이므로 `infra` 소속입니다.
 ## 네이밍 정책
 
 - 초기 CQRS 단계에서는 `*CommandService`, `*QueryService`를 우선 사용합니다.
-- `Host`, `Participant` 같은 행위 축은 당장 클래스명으로 올리지 않습니다.
+- `Host`, `Participant` 같은 행위 축은 당장 클래스명으로 올리지 않고 메서드 책임으로 먼저 검증합니다.
 - `Rule`, `Reader`, `Writer`, `DomainService`는 실제 복잡도가 확인된 뒤 후속 이슈에서 분리합니다.
+- query 전용 협력 객체는 service와 같은 축에 두고(`application/query`, `infra/query`) 이름으로 역할을 드러냅니다.
 
 ## 1차 적용 대상
 

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/query/ConcertQueryService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/query/ConcertQueryService.java
@@ -7,7 +7,7 @@ import com.backend.allreva.module.concert.concert.application.dto.ConcertDetailR
 import com.backend.allreva.module.concert.concert.application.dto.ConcertThumbnail;
 import com.backend.allreva.module.concert.concert.application.dto.RelatedConcertResponse;
 import com.backend.allreva.module.concert.concert.application.dto.SortDirection;
-import com.backend.allreva.module.concert.concert.application.port.ConcertSearchRepository;
+import com.backend.allreva.module.concert.concert.application.query.port.ConcertSearchRepository;
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
 import com.backend.allreva.module.concert.concert.exception.ConcertErrorCode;

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/query/port/ConcertSearchRepository.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/query/port/ConcertSearchRepository.java
@@ -1,4 +1,4 @@
-package com.backend.allreva.module.concert.concert.application.port;
+package com.backend.allreva.module.concert.concert.application.query.port;
 
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertThumbnail;

--- a/src/main/java/com/backend/allreva/module/concert/concert/infra/query/ConcertSearchRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/infra/query/ConcertSearchRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.backend.allreva.module.concert.concert.infra;
+package com.backend.allreva.module.concert.concert.infra.query;
 
 import static com.backend.allreva.module.concert.concert.domain.QConcert.concert;
 import static com.backend.allreva.module.concert.place.domain.QConcertHall.concertHall;
@@ -6,7 +6,7 @@ import static com.backend.allreva.module.concert.place.domain.QConcertHall.conce
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.module.concert.concert.application.dto.ConcertThumbnail;
 import com.backend.allreva.module.concert.concert.application.dto.SortDirection;
-import com.backend.allreva.module.concert.concert.application.port.ConcertSearchRepository;
+import com.backend.allreva.module.concert.concert.application.query.port.ConcertSearchRepository;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/application/query/RentQueryService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/application/query/RentQueryService.java
@@ -15,7 +15,7 @@ import com.backend.allreva.module.recruitment.rent.application.query.dto.RentPar
 import com.backend.allreva.module.recruitment.rent.application.query.dto.RentSummaryResponse;
 import com.backend.allreva.module.recruitment.rent.application.query.dto.RentThumbnail;
 import com.backend.allreva.module.recruitment.rent.application.query.dto.SortType;
-import com.backend.allreva.module.recruitment.rent.application.port.RentSearchRepository;
+import com.backend.allreva.module.recruitment.rent.application.query.port.RentSearchRepository;
 import com.backend.allreva.module.recruitment.rent.domain.Rent;
 import com.backend.allreva.module.recruitment.rent.domain.RentRepository;
 import com.backend.allreva.module.recruitment.rent.domain.participant.RentParticipant;

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/application/query/port/RentSearchRepository.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/application/query/port/RentSearchRepository.java
@@ -1,4 +1,4 @@
-package com.backend.allreva.module.recruitment.rent.application.port;
+package com.backend.allreva.module.recruitment.rent.application.query.port;
 
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.module.recruitment.rent.application.query.dto.RentThumbnail;

--- a/src/main/java/com/backend/allreva/module/recruitment/rent/infra/query/RentSearchRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/rent/infra/query/RentSearchRepositoryImpl.java
@@ -1,10 +1,10 @@
-package com.backend.allreva.module.recruitment.rent.infra;
+package com.backend.allreva.module.recruitment.rent.infra.query;
 
 import static com.backend.allreva.module.recruitment.rent.domain.QRent.rent;
 
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.module.recruitment.rent.application.query.dto.RentThumbnail;
-import com.backend.allreva.module.recruitment.rent.application.port.RentSearchRepository;
+import com.backend.allreva.module.recruitment.rent.application.query.port.RentSearchRepository;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/application/command/SurveyCommandService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/application/command/SurveyCommandService.java
@@ -16,13 +16,16 @@ import com.backend.allreva.module.recruitment.survey.domain.SurveyRepository;
 import com.backend.allreva.module.recruitment.survey.domain.participant.SurveyParticipant;
 import com.backend.allreva.module.recruitment.survey.domain.participant.SurveyParticipantRepository;
 import com.backend.allreva.module.recruitment.survey.exception.SurveyErrorCode;
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 
 @Service
+@Validated
 @RequiredArgsConstructor
 public class SurveyCommandService {
 
@@ -31,7 +34,7 @@ public class SurveyCommandService {
     private final ConcertRepository concertRepository;
 
     @Transactional
-    public Long openSurvey(final Long memberId, final OpenSurveyRequest request) {
+    public Long openSurvey(final Long memberId, @Valid final OpenSurveyRequest request) {
         validateBoardingDates(request.concertCode(), request.boardingDates());
 
         Survey survey = surveyRepository.save(Survey.builder()
@@ -58,7 +61,7 @@ public class SurveyCommandService {
     }
 
     @Transactional
-    public void updateSurvey(final Long memberId, final UpdateSurveyRequest request) {
+    public void updateSurvey(final Long memberId, @Valid final UpdateSurveyRequest request) {
         Survey survey = findSurvey(request.surveyId());
 
         validateBoardingDates(survey.getConcertCode(), request.boardingDates());
@@ -74,14 +77,14 @@ public class SurveyCommandService {
     }
 
     @Transactional
-    public void removeSurvey(final Long memberId, final SurveyIdRequest surveyIdRequest) {
+    public void removeSurvey(final Long memberId, @Valid final SurveyIdRequest surveyIdRequest) {
         Survey survey = findSurvey(surveyIdRequest.surveyId());
         survey.isWriter(memberId);
         surveyRepository.delete(survey);
     }
 
     @Transactional
-    public Long joinSurvey(final Long memberId, final JoinSurveyRequest request) {
+    public Long joinSurvey(final Long memberId, @Valid final JoinSurveyRequest request) {
         if (surveyParticipantRepository.existsByMemberIdAndSurveyId(memberId, request.surveyId())) {
             throw new CustomException(SurveyErrorCode.SURVEY_JOIN_ALREADY_EXISTS);
         }

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/application/query/SurveyQueryService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/application/query/SurveyQueryService.java
@@ -10,7 +10,7 @@ import com.backend.allreva.module.recruitment.survey.application.dto.SurveyDetai
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveyMainResponse;
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveySummaryResponse;
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveyThumbnail;
-import com.backend.allreva.module.recruitment.survey.application.port.SurveySearchRepository;
+import com.backend.allreva.module.recruitment.survey.application.query.port.SurveySearchRepository;
 import com.backend.allreva.module.recruitment.survey.domain.SurveyRepository;
 import com.backend.allreva.module.recruitment.survey.domain.participant.SurveyParticipantRepository;
 import com.backend.allreva.module.recruitment.survey.domain.value.Region;

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/application/query/port/SurveySearchRepository.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/application/query/port/SurveySearchRepository.java
@@ -1,4 +1,4 @@
-package com.backend.allreva.module.recruitment.survey.application.port;
+package com.backend.allreva.module.recruitment.survey.application.query.port;
 
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveyThumbnail;

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/infra/query/SurveySearchRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/infra/query/SurveySearchRepositoryImpl.java
@@ -1,11 +1,11 @@
-package com.backend.allreva.module.recruitment.survey.infra;
+package com.backend.allreva.module.recruitment.survey.infra.query;
 
 import static com.backend.allreva.module.recruitment.survey.domain.QSurvey.survey;
 import static com.backend.allreva.module.recruitment.survey.domain.participant.QSurveyParticipant.surveyParticipant;
 
 import com.backend.allreva.common.pagination.SliceResponse;
 import com.backend.allreva.module.recruitment.survey.application.dto.SurveyThumbnail;
-import com.backend.allreva.module.recruitment.survey.application.port.SurveySearchRepository;
+import com.backend.allreva.module.recruitment.survey.application.query.port.SurveySearchRepository;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;

--- a/src/test/java/com/backend/allreva/module/recruitment/survey/validation/SurveyCommandValidationIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/recruitment/survey/validation/SurveyCommandValidationIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.backend.allreva.module.recruitment.survey.validation;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.backend.allreva.module.recruitment.survey.application.command.SurveyCommandService;
+import com.backend.allreva.module.recruitment.survey.application.dto.JoinSurveyRequest;
+import com.backend.allreva.module.recruitment.survey.application.dto.OpenSurveyRequest;
+import com.backend.allreva.module.recruitment.survey.domain.value.BoardingType;
+import com.backend.allreva.module.recruitment.survey.domain.value.Region;
+import com.backend.allreva.support.IntegrationTestSupport;
+import jakarta.validation.ConstraintViolationException;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("Survey Command 서비스 검증 테스트")
+class SurveyCommandValidationIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private SurveyCommandService surveyCommandService;
+
+    @Test
+    @DisplayName("openSurvey는 controller 없이도 DTO 제약을 검증한다")
+    void openSurvey_validates_request_in_service_layer() {
+        OpenSurveyRequest invalidRequest = new OpenSurveyRequest(
+                "",
+                "PFMOCK001",
+                List.of(LocalDate.now().plusDays(1)),
+                Region.서울,
+                LocalDate.now().plusDays(2),
+                1,
+                "안내");
+
+        assertThatThrownBy(() -> surveyCommandService.openSurvey(1L, invalidRequest))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("title");
+    }
+
+    @Test
+    @DisplayName("joinSurvey는 controller 없이도 DTO 제약을 검증한다")
+    void joinSurvey_validates_request_in_service_layer() {
+        JoinSurveyRequest invalidRequest =
+                new JoinSurveyRequest(null, LocalDate.now().plusDays(1), BoardingType.UP, 1, false);
+
+        assertThatThrownBy(() -> surveyCommandService.joinSurvey(1L, invalidRequest))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("surveyId");
+    }
+}


### PR DESCRIPTION
## 작업 내용
`#83`의 첫 단계로, CQRS를 적용한 뒤에도 query 전용 협력 객체가 `application/port`, `infra` 루트에 섞여 있던 부분을 정리했습니다. 이번 변경은 역할을 더 세분화하기보다, query 축에 속한 계약과 구현을 같은 축으로 모아 네이밍과 위치를 먼저 맞추는 데 집중했습니다.

## 구현
- rent / survey / concert의 `*SearchRepository` 계약을 `application/query/port`로 이동
- 각 구현체를 `infra/query`로 이동
- `RentQueryService`, `SurveyQueryService`, `ConcertQueryService` import 정리
- `MODULE_PACKAGE_POLICY.md`에 query 협력 객체 배치 기준 반영

## 테스트
- `./gradlew :apps:api-server:compileJava :apps:api-server:compileTestJava`
- `./gradlew :apps:api-server:test --tests '*RentQueryIntegrationTest' --tests '*SurveyIntegrationTest' --tests '*ConcertIntegrationTest'`
- `./gradlew spotlessApply spotlessCheck`

Closes #83
