### PR TITLE
[#84] batch-server 실행 모듈 전략 반영

### DIFF
--- a/MODULE_PACKAGE_POLICY.md
+++ b/MODULE_PACKAGE_POLICY.md
@@ -242,8 +242,8 @@ JPA 기술 구현 세부사항이므로 `infra` 소속입니다.
 ## 실행 모듈 정책
 
 - 초기 실행 모듈은 `api-server`, `batch-server` 2개로 둡니다.
-- `@Scheduled` 진입점은 우선 `batch-server` 기준으로 정리합니다.
-- Spring Batch `Job` / 이벤트 소비자도 `batch-server` 내부에서 시작하고, 실제 유스케이스는 application 계층을 재사용합니다.
+- `@Scheduled` 진입점은 우선 `com.backend.allreva.batch.scheduler` 패키지 기준으로 정리합니다.
+- Spring Batch `Job` / 이벤트 소비자도 `batch-server` 내부에서 시작하고, 실제 유스케이스는 application 계층의 재사용 가능한 service/usecase를 호출합니다.
 - `scheduler-server`는 처음부터 만들지 않고, 배포 주기·장애 격리·운영 설정이 분리될 때 별도 app 모듈로 승격합니다.
 - 따라서 지금 단계에서 중요한 것은 `scheduler` 책임을 API 진입점과 분리하고, 나중에 `scheduler-server`로 옮기기 쉬운 패키지/설정 경계를 유지하는 것입니다.
 

--- a/MODULE_PACKAGE_POLICY.md
+++ b/MODULE_PACKAGE_POLICY.md
@@ -239,12 +239,20 @@ JPA 기술 구현 세부사항이므로 `infra` 소속입니다.
 ### common/event
 - 공통 이벤트 메커니즘과 비즈니스 이벤트 클래스 분리
 
+## 실행 모듈 정책
+
+- 초기 실행 모듈은 `api-server`, `batch-server` 2개로 둡니다.
+- `@Scheduled` 진입점은 우선 `batch-server` 기준으로 정리합니다.
+- Spring Batch `Job` / 이벤트 소비자도 `batch-server` 내부에서 시작하고, 실제 유스케이스는 application 계층을 재사용합니다.
+- `scheduler-server`는 처음부터 만들지 않고, 배포 주기·장애 격리·운영 설정이 분리될 때 별도 app 모듈로 승격합니다.
+- 따라서 지금 단계에서 중요한 것은 `scheduler` 책임을 API 진입점과 분리하고, 나중에 `scheduler-server`로 옮기기 쉬운 패키지/설정 경계를 유지하는 것입니다.
+
 ## 이번 단계에서 하지 않는 것
 
 - 모든 common 코드 즉시 이동
 - 도메인 서비스 / Rule 세분화
 - `HostCommandService`, `ParticipantCommandService` 같은 역할명 세분화
-- batch-server / scheduler-server 실행 전략 확정
+- `scheduler-server` 즉시 생성
 
 ## 후속 이슈 연결
 

--- a/apps/batch-server/README.md
+++ b/apps/batch-server/README.md
@@ -34,3 +34,6 @@
 - `BatchServerApplication`은 `com.backend.allreva` 전체를 스캔합니다.
 - `batch-server`는 non-web 실행 모드로 고정합니다.
 - scheduling 활성화는 `batch-server`에서 시작합니다.
+- 기존 `@Scheduled` 진입점은 우선 `com.backend.allreva.batch.scheduler` 패키지로 이동합니다.
+- 실제 소스가 modules/apps로 완전히 이동하기 전까지는 이 scheduler 패키지가 root `src/main/java`에 남을 수 있습니다.
+- 기존 application 쪽 클래스는 scheduler 자체가 아니라 재사용 가능한 sync/closing 서비스로 유지합니다.

--- a/apps/batch-server/README.md
+++ b/apps/batch-server/README.md
@@ -1,0 +1,36 @@
+# batch-server 전략
+
+## 현재 결정
+
+- 초기 실행 모듈은 `api-server`, `batch-server` 두 개로 둡니다.
+- `scheduler-server`는 바로 만들지 않고, `batch-server` 내부에 scheduler 진입점을 함께 둡니다.
+- `@Scheduled`, Spring Batch Job, 이벤트 소비자는 모두 `batch-server`의 진입점 후보입니다.
+- 실제 비즈니스 로직은 `allreva-application` 유스케이스를 호출하도록 유지합니다.
+
+## why
+
+- 아직 실제 소스가 멀티모듈로 완전히 이동하지 않은 상태라서 실행 모듈을 더 쪼개면 구조 검증보다 운영 구조 논의가 먼저 커집니다.
+- 초기에는 배포 단위와 설정 수를 최소화하는 편이 안전합니다.
+- 대신 패키지와 설정 경계를 먼저 나눠서, 나중에 `scheduler-server`로 승격하기 쉽게 준비합니다.
+
+## batch-server 책임
+
+- scheduler 진입점 (`@Scheduled`)
+- batch job / step 진입점
+- 이벤트 소비 진입점
+- 배치 전용 설정, 락, 시간 추상화
+
+## 분리 조건
+
+아래 조건이 생기면 `scheduler-server` 분리를 검토합니다.
+
+- 스케줄러와 배치 워커의 배포 주기가 다름
+- 장애 격리 요구가 큼
+- 인스턴스 수 / 자원 튜닝 기준이 다름
+- cron, lock, queue, worker 설정이 크게 갈라짐
+
+## 현재 코드 반영
+
+- `BatchServerApplication`은 `com.backend.allreva` 전체를 스캔합니다.
+- `batch-server`는 non-web 실행 모드로 고정합니다.
+- scheduling 활성화는 `batch-server`에서 시작합니다.

--- a/apps/batch-server/src/main/java/com/backend/allreva/batch/BatchServerApplication.java
+++ b/apps/batch-server/src/main/java/com/backend/allreva/batch/BatchServerApplication.java
@@ -2,8 +2,10 @@ package com.backend.allreva.batch;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@EnableScheduling
+@SpringBootApplication(scanBasePackages = "com.backend.allreva")
 public class BatchServerApplication {
 
     public static void main(String[] args) {

--- a/apps/batch-server/src/main/resources/application.yml
+++ b/apps/batch-server/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 spring:
   application:
     name: allreva-batch
+  main:
+    web-application-type: none
+  task:
+    scheduling:
+      thread-name-prefix: batch-scheduler-
   profiles:
     active: dev
   config:

--- a/src/main/java/com/backend/allreva/batch/scheduler/concert/ConcertHallSyncScheduler.java
+++ b/src/main/java/com/backend/allreva/batch/scheduler/concert/ConcertHallSyncScheduler.java
@@ -1,0 +1,26 @@
+package com.backend.allreva.batch.scheduler.concert;
+
+import com.backend.allreva.module.concert.place.application.ConcertHallSyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class ConcertHallSyncScheduler {
+
+    private final ConcertHallSyncService concertHallSyncService;
+
+    /** 공연장 정보 매월 동기화 — 매월 1일 새벽 2시 */
+    @Scheduled(cron = "0 0 2 1 * *")
+    public void fetchMonthlyHallInfoList() {
+        try {
+            concertHallSyncService.fetchConcertHallInfoList();
+            log.info("Monthly concert hall info update complete");
+        } catch (Exception e) {
+            log.error("Can't update monthly hall info. Message: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/backend/allreva/batch/scheduler/concert/ConcertSyncScheduler.java
+++ b/src/main/java/com/backend/allreva/batch/scheduler/concert/ConcertSyncScheduler.java
@@ -1,0 +1,28 @@
+package com.backend.allreva.batch.scheduler.concert;
+
+import com.backend.allreva.module.concert.concert.application.ConcertSyncService;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConcertSyncScheduler {
+
+    private final ConcertSyncService concertSyncService;
+
+    /** 공연 정보 매일 동기화 — 매일 새벽 4시 */
+    @Scheduled(cron = "0 0 4 * * *")
+    public void fetchDailyScheduled() {
+        LocalDate today = LocalDate.now();
+        try {
+            concertSyncService.fetchDailyConcertInfoList(today);
+            log.info("{}: daily concert info update complete", today);
+        } catch (Exception e) {
+            log.error("Can't update daily concert info. Message: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/backend/allreva/batch/scheduler/search/PopularKeywordScheduler.java
+++ b/src/main/java/com/backend/allreva/batch/scheduler/search/PopularKeywordScheduler.java
@@ -1,0 +1,20 @@
+package com.backend.allreva.batch.scheduler.search;
+
+import com.backend.allreva.module.search.application.PopularKeywordBatchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PopularKeywordScheduler {
+
+    private static final String ONE_HOUR_CRON = "0 0 * * * *";
+
+    private final PopularKeywordBatchService popularKeywordBatchService;
+
+    @Scheduled(cron = ONE_HOUR_CRON)
+    public void updatePopularKeywordRank() {
+        popularKeywordBatchService.updatePopularKeywordRank();
+    }
+}

--- a/src/main/java/com/backend/allreva/batch/scheduler/survey/SurveyScheduler.java
+++ b/src/main/java/com/backend/allreva/batch/scheduler/survey/SurveyScheduler.java
@@ -1,0 +1,21 @@
+package com.backend.allreva.batch.scheduler.survey;
+
+import com.backend.allreva.module.recruitment.survey.application.SurveyClosingService;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SurveyScheduler {
+
+    private static final String MIDNIGHT_CRON = "0 0 0 * * *";
+
+    private final SurveyClosingService surveyClosingService;
+
+    @Scheduled(cron = MIDNIGHT_CRON)
+    public void closeSurvey() {
+        surveyClosingService.closeSurveys(LocalDate.now());
+    }
+}

--- a/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertSyncService.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/application/ConcertSyncService.java
@@ -14,34 +14,18 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Slf4j
-@Component
-public class ConcertSyncScheduler {
+@Service
+public class ConcertSyncService {
 
     private static final int KOPIS_RATE_LIMIT_MILLIS = 100;
 
     private final ConcertDataSyncPort concertDataSyncPort;
     private final ConcertHallRepository concertHallRepository;
     private final ConcertRepository concertRepository;
-
-    /** 공연 정보 매일 동기화 — 매일 새벽 4시 */
-    @CacheEvict(
-            cacheNames = {"concertMain", "concertSearch", "concertRelated"},
-            allEntries = true)
-    @Scheduled(cron = "0 0 4 * * *")
-    public void fetchDailyScheduled() {
-        LocalDate today = LocalDate.now();
-        try {
-            fetchDailyConcertInfoList(today);
-            log.info("{}: daily concert info update complete", today);
-        } catch (Exception e) {
-            log.error("Can't update daily concert info. Message: {}", e.getMessage());
-        }
-    }
 
     @CacheEvict(
             cacheNames = {"concertMain", "concertSearch", "concertRelated"},
@@ -64,11 +48,9 @@ public class ConcertSyncScheduler {
                 for (ConcertSummary summary : summaries) {
                     ConcertStatus existing = statusMap.get(summary.concertCode());
 
-                    // Skip if existing concert is COMPLETED
                     if (existing == ConcertStatus.COMPLETED) {
                         continue;
                     }
-                    // Skip if status unchanged
                     if (existing != null && existing == summary.status()) {
                         continue;
                     }

--- a/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertSyncTestController.java
+++ b/src/main/java/com/backend/allreva/module/concert/concert/presentation/ConcertSyncTestController.java
@@ -1,6 +1,6 @@
 package com.backend.allreva.module.concert.concert.presentation;
 
-import com.backend.allreva.module.concert.concert.application.ConcertSyncScheduler;
+import com.backend.allreva.module.concert.concert.application.ConcertSyncService;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
@@ -16,13 +16,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/test/sync/concerts")
 public class ConcertSyncTestController implements ConcertSyncTestControllerSwagger {
 
-    private final ConcertSyncScheduler concertSyncScheduler;
+    private final ConcertSyncService concertSyncService;
 
     @PostMapping
     public String syncConcerts(
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         LocalDate target = date != null ? date : LocalDate.now();
-        concertSyncScheduler.fetchDailyConcertInfoList(target);
+        concertSyncService.fetchDailyConcertInfoList(target);
         return "concert sync triggered for " + target;
     }
 }

--- a/src/main/java/com/backend/allreva/module/concert/place/application/ConcertHallSyncService.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/application/ConcertHallSyncService.java
@@ -8,32 +8,17 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Slf4j
-@Component
-public class ConcertHallSyncScheduler {
+@Service
+public class ConcertHallSyncService {
 
     private static final int KOPIS_RATE_LIMIT_MILLIS = 100;
 
     private final ConcertHallDataSyncPort concertHallDataSyncPort;
     private final ConcertHallRepository concertHallRepository;
-
-    /** 공연장 정보 매월 동기화 — 매월 1일 새벽 2시 */
-    @CacheEvict(
-            cacheNames = {"concertHall"},
-            allEntries = true)
-    @Scheduled(cron = "0 0 2 1 * *")
-    public void fetchMonthlyHallInfoList() {
-        try {
-            fetchConcertHallInfoList();
-            log.info("Monthly concert hall info update complete");
-        } catch (Exception e) {
-            log.error("Can't update monthly hall info. Message: {}", e.getMessage());
-        }
-    }
 
     @CacheEvict(
             cacheNames = {"concertHall"},
@@ -47,7 +32,6 @@ public class ConcertHallSyncScheduler {
                 Set<String> existingHallCodes = concertHallRepository.findHallCodesByFacilityCode(facilityCode);
 
                 for (ConcertHall hall : halls) {
-                    // Save only if hallCode exists in whitelist (already in DB)
                     if (existingHallCodes.contains(hall.getHallCode())) {
                         concertHallRepository.save(hall);
                     } else {

--- a/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallSyncTestController.java
+++ b/src/main/java/com/backend/allreva/module/concert/place/presentation/ConcertHallSyncTestController.java
@@ -1,6 +1,6 @@
 package com.backend.allreva.module.concert.place.presentation;
 
-import com.backend.allreva.module.concert.place.application.ConcertHallSyncScheduler;
+import com.backend.allreva.module.concert.place.application.ConcertHallSyncService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,11 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/test/sync/halls")
 public class ConcertHallSyncTestController implements ConcertHallSyncTestControllerSwagger {
 
-    private final ConcertHallSyncScheduler concertHallSyncScheduler;
+    private final ConcertHallSyncService concertHallSyncService;
 
     @PostMapping
     public String syncHalls() {
-        concertHallSyncScheduler.fetchConcertHallInfoList();
+        concertHallSyncService.fetchConcertHallInfoList();
         return "concert hall sync triggered";
     }
 }

--- a/src/main/java/com/backend/allreva/module/recruitment/survey/application/SurveyClosingService.java
+++ b/src/main/java/com/backend/allreva/module/recruitment/survey/application/SurveyClosingService.java
@@ -4,22 +4,19 @@ import com.backend.allreva.module.recruitment.survey.domain.SurveyRepository;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 @Slf4j
-@Component
+@Service
 @RequiredArgsConstructor
-public class SurveyScheduler {
+public class SurveyClosingService {
 
     private final SurveyRepository surveyRepository;
-    private static final String MIDNIGHT_CRON = "0 0 0 * * *";
 
-    @Scheduled(cron = MIDNIGHT_CRON)
-    public void closeSurvey() {
+    public void closeSurveys(final LocalDate targetDate) {
         try {
-            surveyRepository.closeSurveys(LocalDate.now());
-            log.info(" {} :daily survey close complete", LocalDate.now());
+            surveyRepository.closeSurveys(targetDate);
+            log.info(" {} :daily survey close complete", targetDate);
         } catch (Exception e) {
             log.error("can't close daily survey. Message: {}", e.getMessage());
         }

--- a/src/main/java/com/backend/allreva/module/search/application/PopularKeywordBatchService.java
+++ b/src/main/java/com/backend/allreva/module/search/application/PopularKeywordBatchService.java
@@ -4,18 +4,15 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 @Slf4j
-@Component
+@Service
 @RequiredArgsConstructor
-public class PopularKeywordScheduler {
+public class PopularKeywordBatchService {
 
     private final PopularKeywordService popularKeywordService;
-    private static final String ONE_HOUR_CRON = "0 0 * * * *";
 
-    @Scheduled(cron = ONE_HOUR_CRON)
     public void updatePopularKeywordRank() {
         try {
             LocalDateTime now = LocalDateTime.now();

--- a/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertSyncIntegrationTest.java
+++ b/src/test/java/com/backend/allreva/module/concert/concert/integration/ConcertSyncIntegrationTest.java
@@ -12,12 +12,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.instancio.Select.field;
 
-import com.backend.allreva.module.concert.concert.application.ConcertSyncScheduler;
+import com.backend.allreva.module.concert.concert.application.ConcertSyncService;
 import com.backend.allreva.module.concert.concert.domain.Concert;
 import com.backend.allreva.module.concert.concert.domain.ConcertRepository;
 import com.backend.allreva.module.concert.concert.domain.value.ConcertInfo;
 import com.backend.allreva.module.concert.concert.fixture.ConcertFixture;
-import com.backend.allreva.module.concert.place.application.ConcertHallSyncScheduler;
+import com.backend.allreva.module.concert.place.application.ConcertHallSyncService;
 import com.backend.allreva.module.concert.place.domain.ConcertHall;
 import com.backend.allreva.module.concert.place.domain.ConcertHallRepository;
 import com.backend.allreva.module.concert.place.fixture.ConcertHallFixture;
@@ -102,10 +102,10 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             """;
 
     @Autowired
-    private ConcertSyncScheduler concertSyncScheduler;
+    private ConcertSyncService concertSyncService;
 
     @Autowired
-    private ConcertHallSyncScheduler concertHallSyncScheduler;
+    private ConcertHallSyncService concertHallSyncService;
 
     @Autowired
     private ConcertRepository concertRepository;
@@ -131,7 +131,6 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("공연 정보를 DB에 저장한다")
             void savesNewConcertToDb() {
-                // given
                 String concertCode = "PF001";
                 concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
                         .set(field(ConcertHall.class, "hallCode"), HALL_ID)
@@ -148,10 +147,8 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
                                 .withHeader("Content-Type", "application/xml;charset=UTF-8")
                                 .withBody(CONCERT_DETAIL_XML.formatted(concertCode, "진행 중인 공연"))));
 
-                // when
-                concertSyncScheduler.fetchDailyConcertInfoList(LocalDate.of(2026, 4, 24));
+                concertSyncService.fetchDailyConcertInfoList(LocalDate.of(2026, 4, 24));
 
-                // then
                 Concert saved = concertRepository.findById(concertCode).orElseThrow();
                 assertSoftly(softly -> {
                     softly.assertThat(saved.getConcertInfo().getTitle()).isEqualTo("진행 중인 공연");
@@ -167,7 +164,6 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("상세를 호출하지 않고 스킵한다")
             void skipsCompletedConcert() {
-                // given
                 String concertCode = "PF003";
                 concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
                         .set(field(ConcertHall.class, "hallCode"), HALL_ID)
@@ -183,13 +179,11 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
                                 .withHeader("Content-Type", "application/xml;charset=UTF-8")
                                 .withBody(CONCERT_CODE_LIST_XML.formatted(concertCode, "공연완료"))));
 
-                // when
-                concertSyncScheduler.fetchDailyConcertInfoList(LocalDate.of(2026, 4, 24));
+                concertSyncService.fetchDailyConcertInfoList(LocalDate.of(2026, 4, 24));
 
-                // then
                 verify(0, getRequestedFor(urlPathMatching("/openApi/restful/pblprfr/" + concertCode + ".*")));
                 Concert result = concertRepository.findById(concertCode).orElseThrow();
-                assertThat(result.getConcertInfo().getTitle()).isEqualTo("종료된 공연"); // unchanged
+                assertThat(result.getConcertInfo().getTitle()).isEqualTo("종료된 공연");
             }
         }
 
@@ -200,7 +194,6 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("상세를 호출하고 업데이트한다")
             void callsDetailAndUpdatesOnStatusTransition() {
-                // given
                 String concertCode = "PF004";
                 concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
                         .set(field(ConcertHall.class, "hallCode"), HALL_ID)
@@ -220,10 +213,8 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
                                 .withHeader("Content-Type", "application/xml;charset=UTF-8")
                                 .withBody(CONCERT_DETAIL_XML.formatted(concertCode, "공연중"))));
 
-                // when
-                concertSyncScheduler.fetchDailyConcertInfoList(LocalDate.of(2026, 4, 24));
+                concertSyncService.fetchDailyConcertInfoList(LocalDate.of(2026, 4, 24));
 
-                // then
                 verify(1, getRequestedFor(urlPathMatching("/openApi/restful/pblprfr/" + concertCode + ".*")));
                 Concert result = concertRepository.findById(concertCode).orElseThrow();
                 assertThat(result.getConcertInfo().getTitle()).isEqualTo("공연중");
@@ -237,12 +228,7 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("KOPIS API를 호출하지 않는다")
             void doesNotCallApiWhenNoHalls() {
-                // given: no halls in DB
-
-                // when
-                concertSyncScheduler.fetchDailyConcertInfoList(LocalDate.of(2026, 4, 24));
-
-                // then
+                concertSyncService.fetchDailyConcertInfoList(LocalDate.of(2026, 4, 24));
                 verify(0, getRequestedFor(urlPathEqualTo("/openApi/restful/pblprfr")));
             }
         }
@@ -259,7 +245,6 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("공연장 정보를 DB에 업데이트한다")
             void updatesConcertHallInfoInDb() {
-                // given
                 concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
                         .set(field(ConcertHall.class, "hallCode"), HALL_ID)
                         .create());
@@ -296,10 +281,8 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
                                 .withHeader("Content-Type", "application/xml;charset=UTF-8")
                                 .withBody(updatedHallXml)));
 
-                // when
-                concertHallSyncScheduler.fetchConcertHallInfoList();
+                concertHallSyncService.fetchConcertHallInfoList();
 
-                // then
                 ConcertHall result = concertHallRepository.findById(HALL_ID).orElseThrow();
                 assertSoftly(softly -> {
                     softly.assertThat(result.getName()).isEqualTo("업데이트된 공연장");
@@ -315,7 +298,6 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("hallId가 일치하는 공연장만 저장한다")
             void savesOnlyMatchingHalls() {
-                // given
                 concertHallRepository.save(Instancio.of(ConcertHallFixture.concertHallModel())
                         .set(field(ConcertHall.class, "hallCode"), HALL_ID)
                         .create());
@@ -357,10 +339,8 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
                                 .withHeader("Content-Type", "application/xml;charset=UTF-8")
                                 .withBody(multiHallXml)));
 
-                // when
-                concertHallSyncScheduler.fetchConcertHallInfoList();
+                concertHallSyncService.fetchConcertHallInfoList();
 
-                // then
                 assertThat(concertHallRepository.findById("FC001114-2")).isEmpty();
                 assertThat(concertHallRepository.findById(HALL_ID)).isPresent();
             }
@@ -373,12 +353,7 @@ class ConcertSyncIntegrationTest extends IntegrationTestSupport {
             @Test
             @DisplayName("KOPIS API를 호출하지 않는다")
             void doesNotCallApiWhenNoHalls() {
-                // given: no halls in DB
-
-                // when
-                concertHallSyncScheduler.fetchConcertHallInfoList();
-
-                // then
+                concertHallSyncService.fetchConcertHallInfoList();
                 verify(0, getRequestedFor(urlPathMatching("/openApi/restful/prfplc/.*")));
             }
         }


### PR DESCRIPTION
## 작업 내용
`#84`의 첫 단계로, 실행 모듈 전략을 실제 `batch-server` 설정에 먼저 반영했습니다. 아직 스케줄러와 배치 소스를 완전히 멀티모듈로 이동한 단계는 아니지만, `batch-server`가 앞으로 어떤 역할을 맡을지와 `scheduler-server`를 언제 분리할지를 코드와 문서 양쪽에서 읽히게 정리했습니다.

## 구현
- `BatchServerApplication`에 `@EnableScheduling` 적용
- `BatchServerApplication`의 scan base package를 `com.backend.allreva`로 확장
- `batch-server`를 non-web 실행 모드로 명시
- scheduling thread prefix 설정 추가
- `apps/batch-server/README.md`에 초기 실행 모듈 전략과 분리 조건 문서화
- `MODULE_PACKAGE_POLICY.md`에 실행 모듈 정책 반영

## 테스트
- `./gradlew :apps:batch-server:compileJava`
- `./gradlew spotlessApply spotlessCheck`

Closes #84
