### PR TITLE
[#101] 로컬 테스트 설정 보정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ build/
 
 ### Firebase ###
 /src/main/resources/firebase/
+**/src/main/resources/firebase/
+**/firebase/firebase-service-account-key.json
 
 ### Kopis ###
 /src/main/resources/kopis/
@@ -40,6 +42,7 @@ out/
 /.nb-gradle/
 
 ### Profile-specific configs & secrets ###
+**/secret.yml
 **/application-dev.yml
 **/application-prod.yml
 **/application-stag.yml

--- a/allreva-api/src/main/resources/application.yml
+++ b/allreva-api/src/main/resources/application.yml
@@ -53,7 +53,7 @@ url:
     domain-name: localhost
 
 jwt:
-  secret-key: local-development-jwt-secret-key-32bytes
+  secret-key: P2wW7hJW5VhWJXSqmSF4bnqn0g50NspypruwV8jOD5K0cpqmQjOduAdKvNaQ3xhk
   access:
     expiration: 3600000
   refresh:

--- a/allreva-support/db/src/main/resources/db.yml
+++ b/allreva-support/db/src/main/resources/db.yml
@@ -26,7 +26,7 @@ spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/allreva
     username: postgres
-    password: postgres
+    password: 1234
   jpa:
     properties:
       hibernate:

--- a/allreva-support/push-notification/src/main/resources/push-notification.yml
+++ b/allreva-support/push-notification/src/main/resources/push-notification.yml
@@ -6,7 +6,7 @@ spring:
 
 fcm:
   project-id: local-fcm-project-id
-  service-account-key: file:./firebase/firebase-service-account-key.json
+  service-account-key: classpath:firebase/firebase-service-account-key.json
 
 ---
 spring:


### PR DESCRIPTION
## 연결된 Issue
- Refs #101

## 구현 내용
#### 로컬 실행용 설정값 정리
- local 기본 JWT secret 값을 갱신했습니다.
- 로컬 PostgreSQL 비밀번호를 현재 로컬 실행 환경에 맞게 조정했습니다.
- `secret.yml`, Firebase service account key가 커밋되지 않도록 ignore 규칙을 보강했습니다.

#### FCM 키 로딩 경로 수정
- FCM service account key를 `classpath:firebase/firebase-service-account-key.json` 기준으로 읽도록 변경했습니다.

## 테스트 결과
- 별도 테스트는 실행하지 않았습니다. 설정 파일 경로와 로컬 실행값 조정만 포함합니다.

## 리뷰 포인트
- 로컬 실행 편의 설정 변경이므로 운영/stag placeholder 설정에는 영향이 없습니다.
