### PR TITLE
[#106] 온보딩 미완료 회원 상태 추가

### DIFF
--- a/allreva-api/src/main/java/com/backend/allreva/auth/AuthCommandControllerSwagger.java
+++ b/allreva-api/src/main/java/com/backend/allreva/auth/AuthCommandControllerSwagger.java
@@ -10,14 +10,20 @@ import jakarta.validation.constraints.NotBlank;
 @Tag(name = "인증 API", description = "인증 Command API")
 public interface AuthCommandControllerSwagger {
 
-    @Operation(summary = "카카오 로그인", description = "인가코드로 카카오 OAuth2 로그인")
+    @Operation(
+            summary = "카카오 로그인",
+            description =
+                    "인가코드로 카카오 OAuth2 로그인. 응답의 memberStatus가 REGISTERED이면 아직 온보딩이 완료되지 않은 상태이므로, 해당 값을 기준으로 온보딩 페이지를 렌더링합니다.")
     View<AuthUserResponse> authKakaoLogin(
             String authorizationCode, HttpServletRequest request, HttpServletResponse response);
 
     @Operation(summary = "토큰 재발급", description = "refresh token으로 access token 재발급")
     View<Void> reissueToken(@NotBlank String refreshToken, HttpServletRequest request, HttpServletResponse response);
 
-    @Operation(summary = "로그인 체크", description = "refresh token으로 로그인 상태 확인 및 토큰 재발급")
+    @Operation(
+            summary = "로그인 체크",
+            description =
+                    "refresh token으로 로그인 상태 확인 및 토큰 재발급. 응답의 memberStatus가 REGISTERED이면 아직 온보딩이 완료되지 않은 상태이므로, 해당 값을 기준으로 온보딩 페이지를 렌더링합니다.")
     View<AuthUserResponse> loginCheck(
             @NotBlank String refreshToken, HttpServletRequest request, HttpServletResponse response);
 

--- a/allreva-api/src/main/java/com/backend/allreva/auth/AuthUserResponse.java
+++ b/allreva-api/src/main/java/com/backend/allreva/auth/AuthUserResponse.java
@@ -1,10 +1,11 @@
 package com.backend.allreva.auth;
 
 import com.backend.allreva.auth.command.output.AuthResult;
+import com.backend.allreva.member.domain.MemberStatus;
 
-public record AuthUserResponse(String email, String nickname, String profileImageUrl) {
+public record AuthUserResponse(String email, String nickname, String profileImageUrl, MemberStatus memberStatus) {
 
     public static AuthUserResponse from(final AuthResult result) {
-        return new AuthUserResponse(result.email(), result.nickname(), result.profileImageUrl());
+        return new AuthUserResponse(result.email(), result.nickname(), result.profileImageUrl(), result.memberStatus());
     }
 }

--- a/allreva-core/src/main/java/com/backend/allreva/auth/command/implementation/AuthTokenIssuer.java
+++ b/allreva-core/src/main/java/com/backend/allreva/auth/command/implementation/AuthTokenIssuer.java
@@ -25,6 +25,7 @@ public class AuthTokenIssuer {
                 .email(member.getEmail().getEmail())
                 .nickname(member.getMemberInfo().getNickname())
                 .profileImageUrl(member.getMemberInfo().getProfileImageUrl())
+                .memberStatus(member.getMemberStatus())
                 .build();
     }
 }

--- a/allreva-core/src/main/java/com/backend/allreva/auth/command/output/AuthResult.java
+++ b/allreva-core/src/main/java/com/backend/allreva/auth/command/output/AuthResult.java
@@ -1,7 +1,13 @@
 package com.backend.allreva.auth.command.output;
 
+import com.backend.allreva.member.domain.MemberStatus;
 import lombok.Builder;
 
 @Builder
 public record AuthResult(
-        String email, String nickname, String profileImageUrl, String accessToken, String refreshToken) {}
+        String email,
+        String nickname,
+        String profileImageUrl,
+        MemberStatus memberStatus,
+        String accessToken,
+        String refreshToken) {}

--- a/allreva-core/src/main/java/com/backend/allreva/member/command/implementation/MemberInfoUpdater.java
+++ b/allreva-core/src/main/java/com/backend/allreva/member/command/implementation/MemberInfoUpdater.java
@@ -11,5 +11,6 @@ public class MemberInfoUpdater {
     public void update(
             final Member member, final String nickname, final String introduce, final String profileImageUrl) {
         member.updateInfo(nickname, introduce, profileImageUrl);
+        member.completeOnboarding();
     }
 }

--- a/allreva-core/src/main/java/com/backend/allreva/member/command/implementation/MemberRegister.java
+++ b/allreva-core/src/main/java/com/backend/allreva/member/command/implementation/MemberRegister.java
@@ -4,6 +4,7 @@ import com.backend.allreva.common.model.Email;
 import com.backend.allreva.member.domain.LoginProvider;
 import com.backend.allreva.member.domain.Member;
 import com.backend.allreva.member.domain.MemberRole;
+import com.backend.allreva.member.domain.MemberStatus;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,7 @@ public class MemberRegister {
                 .email(Email.builder().email(email).build())
                 .nickname(nickname)
                 .memberRole(MemberRole.USER)
+                .memberStatus(MemberStatus.ACTIVE)
                 .introduce(introduce)
                 .profileImageUrl(profileImageUrl)
                 .loginProvider(loginProvider)
@@ -31,7 +33,17 @@ public class MemberRegister {
     }
 
     public Member registerByOAuth(final String email, final LoginProvider loginProvider, final String profileImageUrl) {
-        return register(email, generateUniqueNickname(), "", loginProvider, profileImageUrl);
+        Member member = Member.builder()
+                .email(Email.builder().email(email).build())
+                .nickname(generateUniqueNickname())
+                .memberRole(MemberRole.USER)
+                .memberStatus(MemberStatus.REGISTERED)
+                .introduce("")
+                .profileImageUrl(profileImageUrl)
+                .loginProvider(loginProvider)
+                .build();
+        member.resetRefundAccount();
+        return member;
     }
 
     private String generateUniqueNickname() {

--- a/allreva-core/src/main/java/com/backend/allreva/member/domain/Member.java
+++ b/allreva-core/src/main/java/com/backend/allreva/member/domain/Member.java
@@ -10,6 +10,7 @@ public class Member {
     private Long id;
     private Email email;
     private MemberRole memberRole;
+    private MemberStatus memberStatus;
     private LoginProvider loginProvider;
     private MemberInfo memberInfo;
     private RefundAccount refundAccount;
@@ -19,6 +20,7 @@ public class Member {
             final Long id,
             final Email email,
             final MemberRole memberRole,
+            final MemberStatus memberStatus,
             final LoginProvider loginProvider,
             final MemberInfo memberInfo,
             final RefundAccount refundAccount,
@@ -28,6 +30,7 @@ public class Member {
         this.id = id;
         this.email = email;
         this.memberRole = memberRole;
+        this.memberStatus = memberStatus != null ? memberStatus : MemberStatus.ACTIVE;
         this.loginProvider = loginProvider;
         this.memberInfo = memberInfo != null
                 ? memberInfo
@@ -45,6 +48,12 @@ public class Member {
                 .introduce(introduce)
                 .profileImageUrl(profileImageUrl)
                 .build();
+    }
+
+    public void completeOnboarding() {
+        if (memberStatus == MemberStatus.REGISTERED) {
+            memberStatus = MemberStatus.ACTIVE;
+        }
     }
 
     public void updateRefundAccount(final String bank, final String number) {

--- a/allreva-core/src/main/java/com/backend/allreva/member/domain/MemberStatus.java
+++ b/allreva-core/src/main/java/com/backend/allreva/member/domain/MemberStatus.java
@@ -1,0 +1,6 @@
+package com.backend.allreva.member.domain;
+
+public enum MemberStatus {
+    REGISTERED,
+    ACTIVE
+}

--- a/allreva-support/db/src/main/java/com/backend/allreva/member/MemberEntity.java
+++ b/allreva-support/db/src/main/java/com/backend/allreva/member/MemberEntity.java
@@ -7,6 +7,7 @@ import com.backend.allreva.member.domain.Member;
 import com.backend.allreva.member.domain.MemberConstraints;
 import com.backend.allreva.member.domain.MemberInfo;
 import com.backend.allreva.member.domain.MemberRole;
+import com.backend.allreva.member.domain.MemberStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -48,6 +49,10 @@ public class MemberEntity extends BaseEntity {
     private MemberRole memberRole;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private MemberStatus memberStatus;
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "provider", nullable = false)
     private LoginProvider loginProvider;
 
@@ -67,12 +72,14 @@ public class MemberEntity extends BaseEntity {
             final Long id,
             final String email,
             final MemberRole memberRole,
+            final MemberStatus memberStatus,
             final LoginProvider loginProvider,
             final MemberInfo memberInfo,
             final RefundAccountVO refundAccount) {
         this.id = id;
         this.email = email;
         this.memberRole = memberRole;
+        this.memberStatus = memberStatus;
         this.loginProvider = loginProvider;
         if (memberInfo != null) {
             this.nickname = memberInfo.getNickname();
@@ -87,6 +94,7 @@ public class MemberEntity extends BaseEntity {
                 member.getId(),
                 member.getEmail() != null ? member.getEmail().getEmail() : null,
                 member.getMemberRole(),
+                member.getMemberStatus(),
                 member.getLoginProvider(),
                 member.getMemberInfo(),
                 RefundAccountVO.from(member.getRefundAccount()));
@@ -97,6 +105,7 @@ public class MemberEntity extends BaseEntity {
                 .id(id)
                 .email(email != null ? new Email(email) : null)
                 .memberRole(memberRole)
+                .memberStatus(memberStatus)
                 .loginProvider(loginProvider)
                 .memberInfo(MemberInfo.builder()
                         .nickname(nickname)

--- a/allreva-support/db/src/main/resources/db/migration/V20260629_02__add_member_status.sql
+++ b/allreva-support/db/src/main/resources/db/migration/V20260629_02__add_member_status.sql
@@ -1,0 +1,6 @@
+ALTER TABLE member
+    ADD COLUMN status VARCHAR(255) NOT NULL DEFAULT 'ACTIVE';
+
+ALTER TABLE member
+    ADD CONSTRAINT member_status_check
+        CHECK (status IN ('REGISTERED', 'ACTIVE'));

--- a/allreva-support/db/src/test/java/com/backend/allreva/member/fixture/MemberFixture.java
+++ b/allreva-support/db/src/test/java/com/backend/allreva/member/fixture/MemberFixture.java
@@ -7,6 +7,7 @@ import com.backend.allreva.member.domain.LoginProvider;
 import com.backend.allreva.member.domain.Member;
 import com.backend.allreva.member.domain.MemberInfo;
 import com.backend.allreva.member.domain.MemberRole;
+import com.backend.allreva.member.domain.MemberStatus;
 import com.backend.allreva.member.domain.RefundAccount;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -25,6 +26,7 @@ public final class MemberFixture {
                 .ignore(field(Member.class, "id"))
                 .set(field(Member.class, "email"), new Email(EMAIL))
                 .set(field(Member.class, "memberRole"), MemberRole.USER)
+                .set(field(Member.class, "memberStatus"), MemberStatus.ACTIVE)
                 .set(field(Member.class, "loginProvider"), PROVIDER)
                 .set(field(MemberInfo.class, "nickname"), NICKNAME)
                 .set(field(MemberInfo.class, "introduce"), "소개")

--- a/allreva-test/src/test/java/com/backend/allreva/auth/integration/AuthenticationIntegrationTest.java
+++ b/allreva-test/src/test/java/com/backend/allreva/auth/integration/AuthenticationIntegrationTest.java
@@ -18,6 +18,7 @@ import com.backend.allreva.common.model.Email;
 import com.backend.allreva.member.domain.LoginProvider;
 import com.backend.allreva.member.domain.Member;
 import com.backend.allreva.member.domain.MemberRepository;
+import com.backend.allreva.member.domain.MemberStatus;
 import com.backend.allreva.member.fixture.MemberFixture;
 import com.backend.allreva.support.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterEach;
@@ -120,6 +121,13 @@ class AuthenticationIntegrationTest extends IntegrationTestSupport {
                 assertThat(refreshTokenStorage.findByToken(response.refreshToken()))
                         .isPresent();
             }
+
+            @Test
+            void 온보딩_미완료_상태가_반환된다() {
+                AuthResult response = authService.kakaoLogin("auth-code");
+
+                assertThat(response.memberStatus()).isEqualTo(MemberStatus.REGISTERED);
+            }
         }
 
         @Nested
@@ -145,6 +153,13 @@ class AuthenticationIntegrationTest extends IntegrationTestSupport {
                 AuthResult response = authService.kakaoLogin("auth-code");
 
                 assertThat(response.email()).isEqualTo("existing@kakao.com");
+            }
+
+            @Test
+            void 기존_멤버의_회원_상태가_유지된다() {
+                AuthResult response = authService.kakaoLogin("auth-code");
+
+                assertThat(response.memberStatus()).isEqualTo(MemberStatus.ACTIVE);
             }
         }
 

--- a/allreva-test/src/test/java/com/backend/allreva/member/fixture/MemberFixture.java
+++ b/allreva-test/src/test/java/com/backend/allreva/member/fixture/MemberFixture.java
@@ -6,6 +6,7 @@ import com.backend.allreva.common.model.Email;
 import com.backend.allreva.member.domain.LoginProvider;
 import com.backend.allreva.member.domain.Member;
 import com.backend.allreva.member.domain.MemberRole;
+import com.backend.allreva.member.domain.MemberStatus;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.instancio.Instancio;
@@ -22,6 +23,7 @@ public final class MemberFixture {
         return Instancio.of(Member.class)
                 .ignore(field(Member.class, "id"))
                 .set(field(Member.class, "memberRole"), MemberRole.USER)
+                .set(field(Member.class, "memberStatus"), MemberStatus.ACTIVE)
                 .set(field(Member.class, "loginProvider"), LoginProvider.GOOGLE)
                 .toModel();
     }

--- a/allreva-test/src/test/java/com/backend/allreva/member/integration/MemberIntegrationTest.java
+++ b/allreva-test/src/test/java/com/backend/allreva/member/integration/MemberIntegrationTest.java
@@ -11,6 +11,7 @@ import com.backend.allreva.member.domain.LoginProvider;
 import com.backend.allreva.member.domain.Member;
 import com.backend.allreva.member.domain.MemberErrorCode;
 import com.backend.allreva.member.domain.MemberRepository;
+import com.backend.allreva.member.domain.MemberStatus;
 import com.backend.allreva.member.domain.NicknameDuplication;
 import com.backend.allreva.member.fixture.MemberFixture;
 import com.backend.allreva.member.fixture.MemberRequestFixture;
@@ -56,6 +57,14 @@ class MemberIntegrationTest extends IntegrationTestSupport {
 
                 assertThat(saved.getMemberInfo().getNickname()).startsWith("user-");
                 assertThat(memberRepository.findById(saved.getId())).isPresent();
+            }
+
+            @Test
+            void 온보딩_미완료_상태로_저장된다() {
+                Member saved = memberCommandService.registerByOAuth(
+                        "newuser@kakao.com", LoginProvider.KAKAO, "https://example.com/profile.jpg");
+
+                assertThat(saved.getMemberStatus()).isEqualTo(MemberStatus.REGISTERED);
             }
         }
 
@@ -125,6 +134,19 @@ class MemberIntegrationTest extends IntegrationTestSupport {
                     softly.assertThat(updatedMember.getMemberInfo().getIntroduce())
                             .isEqualTo(request.introduce());
                 });
+            }
+
+            @Test
+            void 온보딩_미완료_회원이면_일반_회원으로_전환된다() {
+                Member member = memberCommandService.registerByOAuth(
+                        "newuser@kakao.com", LoginProvider.KAKAO, "https://example.com/profile.jpg");
+                MemberInfoUpdateCommand request = Instancio.of(MemberRequestFixture.memberInfoUpdateCommandModel())
+                        .create();
+
+                memberCommandService.updateMemberInfo(request, member.getId());
+                Member updatedMember = memberRepository.findById(member.getId()).orElseThrow();
+
+                assertThat(updatedMember.getMemberStatus()).isEqualTo(MemberStatus.ACTIVE);
             }
         }
     }


### PR DESCRIPTION
## 연결된 Issue
- closed #106

## 구현 내용
#### 온보딩 미완료 회원 상태 추가
- `MemberStatus` enum을 추가해 회원 상태를 `REGISTERED`, `ACTIVE`로 구분했습니다.
- OAuth 로그인으로 신규 생성된 회원은 `REGISTERED` 상태로 저장되도록 했습니다.
- 온보딩 완료에 해당하는 회원 정보 등록 시 회원 상태가 `ACTIVE`로 전환되도록 했습니다.
- 기존 회원 정보 수정 흐름에서는 기존 회원 상태를 유지하도록 분리했습니다.

```text
[OAuth Login 요청]
        |
        v
[OAuth Provider 사용자 정보 조회]
        |
        v
[회원 존재 여부 확인]
        |
        +--------------------------+
        |                          |
        v                          v
 [신규 회원]                  [기존 회원]
        |                          |
        v                          v
[MemberStatus.REGISTERED]    [기존 MemberStatus 유지]
        |                          |
        +------------+-------------+
                     |
                     v
        [accessToken / refreshToken 발급]
                     |
                     v
        [로그인 응답에 memberStatus 포함]
                     |
                     v
        +------------------------------+
        | memberStatus == REGISTERED ? |
        +------------------------------+
              | Yes              | No
              v                  v
 [온보딩 페이지 렌더링]   [서비스 메인 화면 진입]
              |
              v
      [온보딩 정보 등록]
              |
              v
 [MemberStatus.ACTIVE 전환]
```



#### 로그인 응답에 회원 상태 포함
- 카카오 로그인, 로그인 체크 응답에 `memberStatus`를 포함했습니다.
- 별도 `onboardingCompleted` boolean은 두지 않고, `memberStatus == REGISTERED` 여부로 온보딩 미완료 상태를 판단하도록 정리했습니다.

#### DB 매핑 및 마이그레이션 추가
- member 테이블에 `member_status` 컬럼을 추가하는 Flyway migration을 작성했습니다.
- JPA entity와 domain 변환 흐름에 회원 상태 매핑을 추가했습니다.

## 테스트 결과
- `./gradlew spotlessApply` 성공
- `./gradlew spotlessCheck` 성공
- `./gradlew test` 성공
- `./gradlew :allreva-test:test` 성공
  - allreva-test: 108개 통과 / 실패 0개 / 스킵 0개

## 리뷰 포인트
- 프론트에서는 별도 `onboardingCompleted` 필드가 아니라 `memberStatus`가 `REGISTERED`인지 확인해 온보딩 페이지 렌더링 여부를 판단하면 됩니다.
- 현재 상태값은 온보딩 미완료(`REGISTERED`)와 서비스 이용 가능(`ACTIVE`)만 두고, 권한과 회원 상태를 분리하는 방향으로 정리했습니다.

