### PR TITLE
[#107] RefreshToken 쿠키 옵션 설정 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,8 @@ out/
 /.nb-gradle/
 
 ### Profile-specific configs & secrets ###
-**/secret.yml
+**/secret*.yml
+**/secret*.yaml
 **/application-dev.yml
 **/application-prod.yml
 **/application-stag.yml

--- a/allreva-api/src/main/java/com/backend/allreva/auth/AuthCommandController.java
+++ b/allreva-api/src/main/java/com/backend/allreva/auth/AuthCommandController.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,6 +24,9 @@ public class AuthCommandController implements AuthCommandControllerSwagger {
     private final AuthService authCommandService;
     private final RefreshTokenCookieWriter refreshTokenCookieWriter;
 
+    @Value("${auth.jwt.access-token.header}")
+    private String accessTokenHeader;
+
     @Override
     @GetMapping("/token/kakao")
     public View<AuthUserResponse> authKakaoLogin(
@@ -30,60 +34,48 @@ public class AuthCommandController implements AuthCommandControllerSwagger {
             final HttpServletRequest request,
             final HttpServletResponse response) {
         AuthResult authResult = authCommandService.kakaoLogin(authorizationCode);
-        applyAuthTokens(request, response, authResult);
+        applyAuthTokens(response, authResult);
         return View.onSuccess(AuthUserResponse.from(authResult));
     }
 
     @Override
     @GetMapping("/token/reissue")
     public View<Void> reissueToken(
-            @NotBlank @CookieValue(name = "refreshToken", required = false) final String refreshToken,
+            @NotBlank @CookieValue(name = "${auth.jwt.refresh-token.name}", required = false)
+                    final String refreshTokenJwt,
             final HttpServletRequest request,
             final HttpServletResponse response) {
-        AuthResult authResult = authCommandService.reissueAccessToken(refreshToken);
-        applyAuthTokens(request, response, authResult);
+        AuthResult authResult = authCommandService.reissueAccessToken(refreshTokenJwt);
+        applyAuthTokens(response, authResult);
         return View.onSuccess();
     }
 
     @Override
     @GetMapping("/login/check")
     public View<AuthUserResponse> loginCheck(
-            @NotBlank @CookieValue(name = "refreshToken", required = false) final String refreshToken,
+            @NotBlank @CookieValue(name = "${auth.jwt.refresh-token.name}", required = false)
+                    final String refreshTokenJwt,
             final HttpServletRequest request,
             final HttpServletResponse response) {
-        AuthResult authResult = authCommandService.reissueAccessToken(refreshToken);
-        applyAuthTokens(request, response, authResult);
+        AuthResult authResult = authCommandService.reissueAccessToken(refreshTokenJwt);
+        applyAuthTokens(response, authResult);
         return View.onSuccess(AuthUserResponse.from(authResult));
     }
 
     @Override
     @GetMapping("/logout")
     public View<Void> logout(
-            @NotBlank @CookieValue(name = "refreshToken", required = false) final String refreshToken,
+            @NotBlank @CookieValue(name = "${auth.jwt.refresh-token.name}", required = false)
+                    final String refreshTokenJwt,
             final HttpServletRequest request,
             final HttpServletResponse response) {
-        String domainName = extractDomainName(request);
-        authCommandService.logout(refreshToken);
-        refreshTokenCookieWriter.delete(response, domainName);
+        authCommandService.logout(refreshTokenJwt);
+        refreshTokenCookieWriter.delete(response);
         return View.onSuccess();
     }
 
-    private void applyAuthTokens(
-            final HttpServletRequest request, final HttpServletResponse response, final AuthResult authResult) {
-        String domainName = extractDomainName(request);
-        refreshTokenCookieWriter.write(response, authResult.refreshToken(), domainName);
-        response.addHeader("Authorization", "Bearer " + authResult.accessToken());
-    }
-
-    private static String extractDomainName(final HttpServletRequest request) {
-        String origin = request.getHeader("Origin");
-        if (origin != null) {
-            return origin;
-        }
-        String referer = request.getHeader("Referer");
-        if (referer != null) {
-            return referer;
-        }
-        return request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort();
+    private void applyAuthTokens(final HttpServletResponse response, final AuthResult authResult) {
+        refreshTokenCookieWriter.write(response, authResult.refreshToken());
+        response.addHeader(accessTokenHeader, "Bearer " + authResult.accessToken());
     }
 }

--- a/allreva-api/src/main/java/com/backend/allreva/auth/AuthCommandControllerSwagger.java
+++ b/allreva-api/src/main/java/com/backend/allreva/auth/AuthCommandControllerSwagger.java
@@ -18,15 +18,15 @@ public interface AuthCommandControllerSwagger {
             String authorizationCode, HttpServletRequest request, HttpServletResponse response);
 
     @Operation(summary = "토큰 재발급", description = "refresh token으로 access token 재발급")
-    View<Void> reissueToken(@NotBlank String refreshToken, HttpServletRequest request, HttpServletResponse response);
+    View<Void> reissueToken(@NotBlank String refreshTokenJwt, HttpServletRequest request, HttpServletResponse response);
 
     @Operation(
             summary = "로그인 체크",
             description =
                     "refresh token으로 로그인 상태 확인 및 토큰 재발급. 응답의 memberStatus가 REGISTERED이면 아직 온보딩이 완료되지 않은 상태이므로, 해당 값을 기준으로 온보딩 페이지를 렌더링합니다.")
     View<AuthUserResponse> loginCheck(
-            @NotBlank String refreshToken, HttpServletRequest request, HttpServletResponse response);
+            @NotBlank String refreshTokenJwt, HttpServletRequest request, HttpServletResponse response);
 
     @Operation(summary = "로그아웃", description = "refresh token 삭제")
-    View<Void> logout(@NotBlank String refreshToken, HttpServletRequest request, HttpServletResponse response);
+    View<Void> logout(@NotBlank String refreshTokenJwt, HttpServletRequest request, HttpServletResponse response);
 }

--- a/allreva-api/src/main/java/com/backend/allreva/auth/RefreshTokenCookieWriter.java
+++ b/allreva-api/src/main/java/com/backend/allreva/auth/RefreshTokenCookieWriter.java
@@ -1,8 +1,6 @@
 package com.backend.allreva.auth;
 
 import jakarta.servlet.http.HttpServletResponse;
-import java.net.MalformedURLException;
-import java.net.URL;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -11,49 +9,42 @@ import org.springframework.stereotype.Service;
 @Service
 public class RefreshTokenCookieWriter {
 
-    @Value("${jwt.refresh.expiration}")
+    @Value("${auth.jwt.refresh-token.expiration}")
     private int refreshTime;
 
-    @Value("${url.front.domain-name}")
-    private String prodDomainName;
+    @Value("${auth.jwt.refresh-token.name}")
+    private String cookieName;
 
-    public void write(final HttpServletResponse response, final String refreshToken, final String domainName) {
-        String cookieDomain = isLocalhost(domainName) ? null : prodDomainName;
+    @Value("${auth.jwt.refresh-token.cookie.domain}")
+    private String cookieDomain;
+
+    @Value("${auth.jwt.refresh-token.cookie.secure}")
+    private boolean secure;
+
+    @Value("${auth.jwt.refresh-token.cookie.same-site}")
+    private String sameSite;
+
+    public void write(final HttpServletResponse response, final String refreshTokenJwt) {
         response.addHeader(
                 HttpHeaders.SET_COOKIE,
-                buildCookie("refreshToken", refreshToken, cookieDomain, refreshTime)
+                buildCookie(cookieName, refreshTokenJwt, cookieDomain, refreshTime)
                         .toString());
     }
 
-    public void delete(final HttpServletResponse response, final String domainName) {
-        String cookieDomain = isLocalhost(domainName) ? null : prodDomainName;
+    public void delete(final HttpServletResponse response) {
         response.addHeader(
                 HttpHeaders.SET_COOKIE,
-                buildCookie("refreshToken", "", cookieDomain, 0).toString());
+                buildCookie(cookieName, "", cookieDomain, 0).toString());
     }
 
-    private static ResponseCookie buildCookie(
-            final String name, final String value, final String domain, final int maxAge) {
+    private ResponseCookie buildCookie(final String name, final String value, final String domain, final int maxAge) {
         return ResponseCookie.from(name, value)
                 .domain(domain)
                 .path("/")
                 .maxAge(maxAge)
                 .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
+                .secure(secure)
+                .sameSite(sameSite)
                 .build();
-    }
-
-    private static boolean isLocalhost(String domain) {
-        if (domain == null) {
-            return false;
-        }
-        try {
-            URL url = new URL(domain);
-            String host = url.getHost();
-            return host.contains("localhost") || host.contains("127.0.0.1");
-        } catch (MalformedURLException e) {
-            return false;
-        }
     }
 }

--- a/allreva-api/src/main/java/com/backend/allreva/auth/security/JwtAuthenticationFilter.java
+++ b/allreva-api/src/main/java/com/backend/allreva/auth/security/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -28,6 +29,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtService;
     private final UserDetailsService userDetailsService;
+
+    @Value("${auth.jwt.access-token.header}")
+    private String accessTokenHeader;
 
     /** JWT 토큰을 검증하고 권한을 부여합니다. */
     @Override
@@ -70,7 +74,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      * @param request HTTP 요청 객체
      */
     private String extractAccessToken(final HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
+        String bearerToken = request.getHeader(accessTokenHeader);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }

--- a/allreva-api/src/main/java/com/backend/allreva/common/config/CorsConfig.java
+++ b/allreva-api/src/main/java/com/backend/allreva/common/config/CorsConfig.java
@@ -11,18 +11,18 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 public class CorsConfig {
 
-    @Value("${url.front.protocol}")
-    private String frontProtocol;
+    @Value("#{'${cors.allowed-origin-patterns}'.split(',')}")
+    private List<String> allowedOriginPatterns;
 
-    @Value("${url.front.domain}")
-    private String frontDomain;
+    @Value("${auth.jwt.access-token.header}")
+    private String accessTokenHeader;
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
         // 허용할 출처 패턴 설정
-        configuration.setAllowedOriginPatterns(List.of(frontProtocol + "://" + frontDomain));
+        configuration.setAllowedOriginPatterns(allowedOriginPatterns);
 
         // 자격 증명 허용
         configuration.setAllowCredentials(true);
@@ -34,7 +34,7 @@ public class CorsConfig {
         configuration.setAllowedHeaders(List.of("*"));
 
         // 노출할 헤더 설정
-        configuration.setExposedHeaders(List.of("Authorization"));
+        configuration.setExposedHeaders(List.of(accessTokenHeader));
 
         // 최대 캐시 시간 설정 (초 단위)
         configuration.setMaxAge(3600L);

--- a/allreva-api/src/main/java/com/backend/allreva/common/config/SwaggerConfig.java
+++ b/allreva-api/src/main/java/com/backend/allreva/common/config/SwaggerConfig.java
@@ -16,11 +16,14 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 public class SwaggerConfig {
 
-    @Value("${url.back.protocol}")
+    @Value("${swagger.server.protocol}")
     private String protocol;
 
-    @Value("${url.back.domain}")
+    @Value("${swagger.server.domain}")
     private String domain;
+
+    @Value("${auth.jwt.access-token.header}")
+    private String accessTokenHeader;
 
     @Bean
     public OpenAPI customOpenAPI() {
@@ -38,7 +41,7 @@ public class SwaggerConfig {
                 .type(SecurityScheme.Type.HTTP)
                 .scheme("bearer")
                 .bearerFormat("JWT")
-                .name("Authorization")
+                .name(accessTokenHeader)
                 .description("Token: oauth2 로그인을 통해 얻은 토큰을 입력하세요.")
                 .in(SecurityScheme.In.HEADER);
     }

--- a/allreva-api/src/main/resources/application.yml
+++ b/allreva-api/src/main/resources/application.yml
@@ -30,9 +30,12 @@ thread-pool:
     max-size: 10
     queue-capacity: 30
 
-jwt:
-  access:
-    header: Authorization
+auth:
+  jwt:
+    access-token:
+      header: Authorization
+    refresh-token:
+      name: refreshToken
 
 ---
 spring:
@@ -40,22 +43,25 @@ spring:
     activate:
       on-profile: local
 
-url:
-  back:
+swagger:
+  server:
     protocol: http
     domain: localhost:8080
-  front:
-    protocol: http
-    domain: localhost:5173
-    domain-name: localhost
 
-jwt:
-  secret-key: local-jwt-secret-key-must-be-long-enough-for-hmac-signing
-  access:
-    expiration: 3600000
-  refresh:
-    expiration: 1209600033
-    cookie-name: refreshToken
+cors:
+  allowed-origin-patterns: http://localhost:5173
+
+auth:
+  jwt:
+    secret-key: local-jwt-secret-key-must-be-long-enough-for-hmac-signing
+    access-token:
+      expiration: 3600000
+    refresh-token:
+      expiration: 1209600033
+      cookie:
+        domain: ""
+        secure: false
+        same-site: Lax
 
 ---
 spring:
@@ -63,22 +69,25 @@ spring:
     activate:
       on-profile: dev
 
-url:
-  back:
+swagger:
+  server:
     protocol: http
     domain: localhost:8080
-  front:
-    protocol: http
-    domain: localhost:5173
-    domain-name: localhost
 
-jwt:
-  secret-key: P2wW7hJW5VhWJXSqmSF4bnqn0g50NspypruwV8jOD5K0cpqmQjOduAdKvNaQ3xhk
-  access:
-    expiration: 3600000
-  refresh:
-    expiration: 1209600033
-    cookie-name: refreshToken
+cors:
+  allowed-origin-patterns: http://localhost:5173
+
+auth:
+  jwt:
+    secret-key: P2wW7hJW5VhWJXSqmSF4bnqn0g50NspypruwV8jOD5K0cpqmQjOduAdKvNaQ3xhk
+    access-token:
+      expiration: 3600000
+    refresh-token:
+      expiration: 1209600033
+      cookie:
+        domain: ""
+        secure: true
+        same-site: None
 
 ---
 spring:
@@ -86,19 +95,22 @@ spring:
     activate:
       on-profile: "stag | prod"
 
-url:
-  back:
-    protocol: ${BACKEND_PROTOCOL}
-    domain: ${BACKEND_DOMAIN}
-  front:
-    protocol: ${FRONTEND_PROTOCOL}
-    domain: ${FRONTEND_DOMAIN}
-    domain-name: ${FRONTEND_DOMAIN_NAME}
+swagger:
+  server:
+    protocol: ${SWAGGER_SERVER_PROTOCOL}
+    domain: ${SWAGGER_SERVER_DOMAIN}
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
-  access:
-    expiration: ${JWT_ACCESS_EXPIRATION}
-  refresh:
-    expiration: ${JWT_REFRESH_EXPIRATION}
-    cookie-name: ${JWT_REFRESH_COOKIE_NAME}
+cors:
+  allowed-origin-patterns: ${CORS_ALLOWED_ORIGIN_PATTERNS}
+
+auth:
+  jwt:
+    secret-key: ${AUTH_JWT_SECRET_KEY}
+    access-token:
+      expiration: ${AUTH_JWT_ACCESS_TOKEN_EXPIRATION}
+    refresh-token:
+      expiration: ${AUTH_JWT_REFRESH_TOKEN_EXPIRATION}
+      cookie:
+        domain: ${AUTH_JWT_REFRESH_TOKEN_COOKIE_DOMAIN}
+        secure: ${AUTH_JWT_REFRESH_TOKEN_COOKIE_SECURE}
+        same-site: ${AUTH_JWT_REFRESH_TOKEN_COOKIE_SAME_SITE}

--- a/allreva-core/src/main/java/com/backend/allreva/auth/command/implementation/JwtTokenProvider.java
+++ b/allreva-core/src/main/java/com/backend/allreva/auth/command/implementation/JwtTokenProvider.java
@@ -24,9 +24,9 @@ public class JwtTokenProvider {
     private final int refreshTime;
 
     public JwtTokenProvider(
-            @Value("${jwt.secret-key}") final String secretKey,
-            @Value("${jwt.access.expiration}") final int accessTime,
-            @Value("${jwt.refresh.expiration}") final int refreshTime) {
+            @Value("${auth.jwt.secret-key}") final String secretKey,
+            @Value("${auth.jwt.access-token.expiration}") final int accessTime,
+            @Value("${auth.jwt.refresh-token.expiration}") final int refreshTime) {
         this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey));
         this.accessTime = accessTime;
         this.refreshTime = refreshTime;

--- a/allreva-core/src/main/java/com/backend/allreva/common/model/Image.java
+++ b/allreva-core/src/main/java/com/backend/allreva/common/model/Image.java
@@ -1,11 +1,14 @@
 package com.backend.allreva.common.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 public class Image {
     private final String url;
 
-    public Image(final String url) {
+    @JsonCreator
+    public Image(@JsonProperty("url") final String url) {
         this.url = url;
     }
 

--- a/allreva-test/src/test/resources/application.yml
+++ b/allreva-test/src/test/resources/application.yml
@@ -1,11 +1,11 @@
-url:
-  back:
+swagger:
+  server:
     protocol: http
     domain: localhost:8080
-  front:
-    protocol: http
-    domain: localhost:3000
-    domain-name: localhost
+
+cors:
+  allowed-origin-patterns: http://localhost:3000
+
 
 spring:
   jpa:
@@ -38,14 +38,19 @@ spring:
       region:
         static: us-east-1
 
-jwt:
-  secret-key: test-jwt-secret-key-must-be-long-enough-for-hmac
-  access:
-    expiration: 3600000
-    header: Authorization
-  refresh:
-    expiration: 1209600033
-    cookie-name: refreshToken
+auth:
+  jwt:
+    secret-key: test-jwt-secret-key-must-be-long-enough-for-hmac
+    access-token:
+      expiration: 3600000
+      header: Authorization
+    refresh-token:
+      name: refreshToken
+      expiration: 1209600033
+      cookie:
+        domain: ""
+        secure: false
+        same-site: Lax
 
 oauth2:
   kakao:


### PR DESCRIPTION
## 연결된 Issue
- closed #107

## 구현 내용
#### RefreshToken 쿠키 설정 분리
- refresh token 쿠키의 `secure`, `sameSite`, `domain`을 profile별 yml 설정으로 분리했습니다.
- local/test에서는 HTTP 개발 환경을 위해 `secure=false`, `same-site=Lax`, `domain=""`를 사용하도록 정리했습니다.
- `url.back`, `url.front` 범용 설정을 `swagger`, `cors`, `auth.jwt` 설정으로 분리했습니다.

#### JWT/Auth 설정 구조 정리
- JWT 관련 설정을 `auth.jwt` 하위로 모았습니다.
- refresh token 이름, 만료시간, cookie 전달 정책을 `auth.jwt.refresh-token` 아래에서 함께 관리하도록 변경했습니다.
- access token header 설정을 controller/filter/swagger/cors에서 공통 설정값으로 사용하도록 정리했습니다.

#### 기타
- `secret-local.yml` 같은 파일도 ignore되도록 `secret*.yml`, `secret*.yaml` 패턴을 추가했습니다.
- Swagger 문서의 `Image` 객체 요청 형식과 실제 역직렬화가 맞도록 `Image`에 Jackson creator 매핑을 추가했습니다. 이후 공통 VO 객체를 삭제하고 각 domain 내부로 이전시킬 예정입니다.

## 테스트 결과
- `./gradlew spotlessApply spotlessCheck test` 성공

## 리뷰 포인트
- 운영/stag 환경변수는 설정 이름 기준으로 변경했습니다.
  - `AUTH_JWT_SECRET_KEY`
  - `AUTH_JWT_ACCESS_TOKEN_EXPIRATION`
  - `AUTH_JWT_REFRESH_TOKEN_EXPIRATION`
  - `AUTH_JWT_REFRESH_TOKEN_COOKIE_DOMAIN`
  - `AUTH_JWT_REFRESH_TOKEN_COOKIE_SECURE`
  - `AUTH_JWT_REFRESH_TOKEN_COOKIE_SAME_SITE`
- refresh token cookie name은 환경별 값이 아니라 `auth.jwt.refresh-token.name` 공통 설정으로 고정했습니다.
