### PR TITLE
[#119] BE에서 Allreva Harness를 탐색하도록 연결

### DIFF
--- a/.agents/skills/development-flow/SKILL.md
+++ b/.agents/skills/development-flow/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: development-flow
+description: Allreva BE에서 여러 파일·모듈·운영 영향이 있는 변경을 계획, 구현, 검증할 때 사용한다. Allreva_Harness의 공통 실행 흐름과 현재 프로젝트 규칙을 함께 적용한다.
+---
+
+# Allreva BE Development Flow
+
+이 Skill은 공통 흐름을 위한 연결층이다. 한 파일의 명확한 수정처럼 작은 작업에는 사용하지 않는다.
+
+1. 현재 프로젝트의 `AGENTS.md`를 읽고 Docs와 Harness 경로를 계산한다.
+2. `$HARNESS_ROOT/skills/development-flow/SKILL.md`를 읽어 공통 흐름을 따른다.
+3. 구현과 검증은 현재 프로젝트의 테스트·Git 규칙을 우선한다.
+
+Harness 경로가 없으면 추측하지 말고 사용자에게 위치를 확인한다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,8 @@
 
 사람이 읽는 공식 기록은 `Allreva_Docs`에 둔다. worktree에서도 같은 위치를 찾기 위해 아래 순서로 문서 루트를 확인한다.
 
-1. `ALLREVA_DOCS_ROOT` 환경 변수가 있으면 그 경로를 사용한다.
-2. 없으면 primary worktree의 부모 디렉터리 아래 `Allreva_Docs`를 찾는다.
+1. `ALLREVA_DOCS_ROOT` 환경 변수가 설정되어 있고 비어있지 않으면 그 경로를 사용한다.
+2. 없거나 비어 있으면 primary worktree의 부모 디렉터리 아래 `Allreva_Docs`를 찾는다.
 
 ```bash
 MAIN_WORKTREE=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
@@ -31,8 +31,8 @@ DOCS_ROOT="${ALLREVA_DOCS_ROOT:-$(dirname "$MAIN_WORKTREE")/Allreva_Docs}"
 
 Agent 실행 흐름은 로컬 `Allreva_Harness`에 둔다. 사람용 정책은 중앙 Docs를, 실행 절차는 Harness를 기준으로 한다.
 
-1. `ALLREVA_HARNESS_ROOT` 환경 변수가 있으면 그 경로를 사용한다.
-2. 없으면 primary worktree의 부모 디렉터리 아래 `Allreva_Harness`를 찾는다.
+1. `ALLREVA_HARNESS_ROOT` 환경 변수가 설정되어 있고 비어있지 않으면 그 경로를 사용한다.
+2. 없거나 비어 있으면 primary worktree의 부모 디렉터리 아래 `Allreva_Harness`를 찾는다.
 
 ```bash
 MAIN_WORKTREE=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,23 @@ DOCS_ROOT="${ALLREVA_DOCS_ROOT:-$(dirname "$MAIN_WORKTREE")/Allreva_Docs}"
 - 아키텍처와 모듈 경계: `architecture/`
 - Issue·PR·개발 규칙: `rules/`
 - 큰 변경의 검토와 결정: `decisions/`
-- 실험·성능·장애 재현 근거: `evidence/`
 - `archive/`는 보존 자료다. 현재 구현 규칙이나 설계 근거로 사용하지 않는다.
 
 중앙 Docs에 문서가 추가됐다고 이 파일을 항상 바꾸지 않는다. 문서 구조, 항상 지켜야 할 규칙, 반복 실행 절차처럼 Agent의 탐색이나 실행 방식이 바뀔 때만 갱신한다.
+
+## Harness 실행 자산
+
+Agent 실행 흐름은 로컬 `Allreva_Harness`에 둔다. 사람용 정책은 중앙 Docs를, 실행 절차는 Harness를 기준으로 한다.
+
+1. `ALLREVA_HARNESS_ROOT` 환경 변수가 있으면 그 경로를 사용한다.
+2. 없으면 primary worktree의 부모 디렉터리 아래 `Allreva_Harness`를 찾는다.
+
+```bash
+MAIN_WORKTREE=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+HARNESS_ROOT="${ALLREVA_HARNESS_ROOT:-$(dirname "$MAIN_WORKTREE")/Allreva_Harness}"
+```
+
+여러 파일·모듈·운영 영향이 있는 변경에서는 project-local `development-flow` Skill을 먼저 읽는다. 이 Skill은 `$HARNESS_ROOT/skills/development-flow/SKILL.md`를 읽는 얇은 연결층이다. 경로가 없으면 추측하지 말고 사용자에게 위치를 확인한다.
 
 ## 코드 스타일 (Spotless + Palantir)
 


### PR DESCRIPTION
## 배경
로컬 Allreva_Harness에 최소 development-flow Skill을 만들었지만, BE worktree에서 Agent가 같은 경로를 안정적으로 찾을 수 있어야 합니다.

## 이번 PR에서 한 일
- `ALLREVA_HARNESS_ROOT` 우선의 Harness 탐색 규칙을 추가했습니다.
- Harness 공통 Skill을 읽는 project-local `development-flow` 연결 Skill을 추가했습니다.
- 제거된 Docs `evidence/` 경로 참조를 정리했습니다.

## 확인한 내용
- primary worktree와 현재 worktree에서 Docs·Harness 경로 계산 확인
- project-local Skill frontmatter 확인
- `git diff --check` 통과

## 남은 확인 사항
- Codex에서 실제 Harness 흐름의 토큰·정확도 평가는 사용자 지시에 따라 별도로 진행합니다.

## 관련 문서
- 기준 문서: Allreva_Docs#15

## 관련 Issue
- closes #119