### PR TITLE
[#121] BE 코드와 테스트 규칙을 연결한다

### DIFF
--- a/.agents/skills/backend-java-conventions/SKILL.md
+++ b/.agents/skills/backend-java-conventions/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: backend-java-conventions
+description: Apply Allreva BE's Java 17, Spring, domain, transaction, exception, and Spotless conventions when writing or reviewing backend Java code.
+---
+
+# Allreva BE Java Conventions
+
+Before writing or reviewing Java code, resolve `DOCS_ROOT` from `ALLREVA_DOCS_ROOT` or the parent of the primary worktree. Read `$DOCS_ROOT/rules/backend-code-conventions.md` as the human-readable source of truth.
+
+Apply the current codebase pattern and that document before generic Java preferences. In particular:
+
+- preserve the documented module dependency direction and domain/application/API/support responsibilities
+- use `CustomException` with the domain `*ErrorCode` for business failures
+- keep query transactions read-only and declare write transactions explicitly
+- use records for DTOs unless a concrete framework or mutability constraint requires a class
+- let Spotless and Palantir Java Format determine imports and whitespace
+
+After Java changes, run the relevant Gradle tests and:
+
+```bash
+./gradlew spotlessApply
+./gradlew spotlessCheck
+```

--- a/.agents/skills/backend-testing-conventions/SKILL.md
+++ b/.agents/skills/backend-testing-conventions/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: backend-testing-conventions
+description: Apply Allreva BE's unit, DB slice, external adapter, and integration-test conventions when adding or reviewing Java tests.
+---
+
+# Allreva BE Testing Conventions
+
+Before adding or reviewing a test, resolve `DOCS_ROOT` from `ALLREVA_DOCS_ROOT` or the parent of the primary worktree. Read `$DOCS_ROOT/rules/backend-test-conventions.md` as the human-readable source of truth.
+
+Choose the narrowest test boundary that proves the changed behavior:
+
+- unit test for pure domain behavior, mappers, and isolated collaborators
+- `DataJpaTestSupport` for JPA repositories and DB adapters
+- module test support with WireMock for external HTTP boundaries
+- `IntegrationTestSupport` in `allreva-test` for application wiring across modules
+
+Follow the documented JUnit 5, AssertJ, BDDMockito, Fixture, cleanup, and exception-assertion rules. Do not use a generic test directory template; place the test in the Gradle module that owns the production code.
+
+Run the changed module's tests first, then the full required validation:
+
+```bash
+./gradlew :<module>:test
+./gradlew test
+./gradlew spotlessCheck
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,84 +2,25 @@
 
 ## Project Scope
 
-이 파일은 **Allreva_BE_Forked 프로젝트 전용 작업 규칙**을 정의한다.
-전역 하네스 사용법이나 일반적인 워크플로우 강제보다,
-이 프로젝트의 아키텍처·스타일·탐색 규칙을 우선한다.
+This file is a navigation layer for Allreva BE. Human-readable rules and decisions live in `Allreva_Docs`; executable workflows and agent roles live in `Allreva_Harness`.
 
-## 문서 시스템
+## Documentation and Harness Roots
 
-사람이 읽는 공식 기록은 `Allreva_Docs`에 둔다. worktree에서도 같은 위치를 찾기 위해 아래 순서로 문서 루트를 확인한다.
-
-1. `ALLREVA_DOCS_ROOT` 환경 변수가 설정되어 있고 비어있지 않으면 그 경로를 사용한다.
-2. 없거나 비어 있으면 primary worktree의 부모 디렉터리 아래 `Allreva_Docs`를 찾는다.
+Resolve the primary worktree first, then use the environment override when it is set:
 
 ```bash
 MAIN_WORKTREE=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
 DOCS_ROOT="${ALLREVA_DOCS_ROOT:-$(dirname "$MAIN_WORKTREE")/Allreva_Docs}"
-```
-
-작업 전에는 `$DOCS_ROOT/INDEX.md`에서 현재 기준 문서를 찾는다. 해당 디렉터리가 없다면 추측하지 말고 사용자에게 위치를 확인한다.
-
-- 아키텍처와 모듈 경계: `architecture/`
-- Issue·PR·개발 규칙: `rules/`
-- 큰 변경의 검토와 결정: `decisions/`
-- `archive/`는 보존 자료다. 현재 구현 규칙이나 설계 근거로 사용하지 않는다.
-
-중앙 Docs에 문서가 추가됐다고 이 파일을 항상 바꾸지 않는다. 문서 구조, 항상 지켜야 할 규칙, 반복 실행 절차처럼 Agent의 탐색이나 실행 방식이 바뀔 때만 갱신한다.
-
-## Harness 실행 자산
-
-Agent 실행 흐름은 로컬 `Allreva_Harness`에 둔다. 사람용 정책은 중앙 Docs를, 실행 절차는 Harness를 기준으로 한다.
-
-1. `ALLREVA_HARNESS_ROOT` 환경 변수가 설정되어 있고 비어있지 않으면 그 경로를 사용한다.
-2. 없거나 비어 있으면 primary worktree의 부모 디렉터리 아래 `Allreva_Harness`를 찾는다.
-
-```bash
-MAIN_WORKTREE=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
 HARNESS_ROOT="${ALLREVA_HARNESS_ROOT:-$(dirname "$MAIN_WORKTREE")/Allreva_Harness}"
 ```
 
-여러 파일·모듈·운영 영향이 있는 변경에서는 project-local `development-flow` Skill을 먼저 읽는다. 이 Skill은 `$HARNESS_ROOT/skills/development-flow/SKILL.md`를 읽는 얇은 연결층이다. 경로가 없으면 추측하지 말고 사용자에게 위치를 확인한다.
+Before work, read `$DOCS_ROOT/INDEX.md` and the applicable current document. Do not use `archive/` as a current implementation rule. If either root is unavailable, ask the user for its location rather than guessing.
 
-## 코드 스타일 (Spotless + Palantir)
+## Rules and Skills
 
-프로젝트는 **Palantir Java Format**을 사용한다. 코드 작성 후 반드시 아래 명령을 실행한다.
-
-```bash
-./gradlew spotlessApply
-./gradlew spotlessCheck
-```
-
-Palantir가 import 정렬, 미사용 import 제거, 공백/줄바꿈/들여쓰기를 자동 처리한다.
-따라서 import 순서는 직접 맞추려 하지 말고 `spotlessApply` 결과를 따른다.
-
-### Git Lint 도구
-
-- **git-branch**: 이슈 번호와 컨벤션을 받아 최신 base 브랜치에서 네이밍 규칙에 맞는 브랜치 생성
-- **git-commit**: git diff와 git log를 분석해 컨벤션에 맞는 커밋 메시지 생성, 여러 단위 변경 시 커밋 분리 제안
-- **github-issue**: 이슈 번호(#12 형식)로 이슈 생성 후 branch 연결, 새 기능/버그 수정/개선 작업 시작 시 사용
-- **github-pr**: 커밋과 diff 분석해 제목·본문·label 자동 구성, 프로젝트 AGENTS.md의 PR 컨벤션 우선 적용
-
-## 아키텍처 제약
-
-- **레이어**: `domain` → `application` → `presentation` / `infra`
-- **역방향 의존 금지**
-- **애그리거트 간 참조**: 직접 객체 참조 금지, ID로만 참조
-- **예외 처리**: `CustomException` + 도메인별 `*ErrorCode` enum
-- **Service**: `@Transactional(readOnly = true)` 기본, 쓰기 메서드만 `@Transactional`
-
-## Git / Commit / PR
-
-Git, commit, PR 규칙은 전역 컨벤션 또는 별도 합의된 규칙을 따른다.
-이 파일에는 프로젝트 특화 규칙만 추가한다.
-
-Issue와 PR은 정해진 항목을 기계적으로 길게 채우지 않는다. 변경 크기에 맞춰 실제로 바뀐 점, 확인한 내용, 남은 확인 사항을 짧고 사실적으로 쓴다.
-
-### Branch / Worktree
-
-- 기능 작업은 가능하면 현재 workspace에서 바로 브랜치를 따지 말고 **git worktree**로 분리한다.
-- 기본 worktree 경로는 프로젝트 루트 기준 `.worktrees/{type}/{slug}` 형태를 사용한다.
-  - 예: `.worktrees/feat/refresh-token-api-csrf`
-- 브랜치명은 `{type}/#{issue-number}-{slug}` 패턴을 사용한다.
-  - 예: `feat/#72-refresh-token-api-csrf`
-- 메인 workspace는 가능하면 `develop` 상태로 유지한다.
+- Java code or review: read `$DOCS_ROOT/rules/backend-code-conventions.md` and the project-local `backend-java-conventions` Skill.
+- Tests: read `$DOCS_ROOT/rules/backend-test-conventions.md` and the project-local `backend-testing-conventions` Skill.
+- Architecture or module-boundary changes: read `$DOCS_ROOT/architecture/` and `$DOCS_ROOT/decisions/` as applicable.
+- Issue and PR work: read `$DOCS_ROOT/rules/`.
+- Changes spanning multiple files, modules, or operational concerns: read the project-local `development-flow` Skill, which delegates to `$HARNESS_ROOT/skills/development-flow/SKILL.md`.
+- Substantial diffs, unfamiliar areas, and PR preparation: use the Pi `explain-diff` agent exposed by `$HARNESS_ROOT`.


### PR DESCRIPTION
## 배경
BE Java·테스트 기준을 중앙 Docs와 실행 Skill로 연결합니다.

## 이번 PR에서 한 일
- BE AGENTS.md를 Docs·Skill 탐색 전용으로 축소했습니다.
- Java·테스트 규칙용 Skill을 추가했습니다.

## 확인한 내용
- `./gradlew spotlessCheck`

## 남은 확인 사항
- 없음

## 관련 문서
- 기준 문서: Allreva_Docs@d274df6

## 관련 Issue
- closes #121