### PR TITLE
[#123] BE 개발 workflow 연결

### DIFF
--- a/.agents/skills/development-flow/SKILL.md
+++ b/.agents/skills/development-flow/SKILL.md
@@ -5,10 +5,18 @@ description: Allreva BE에서 여러 파일·모듈·운영 영향이 있는 변
 
 # Allreva BE Development Flow
 
-이 Skill은 공통 흐름을 위한 연결층이다. 한 파일의 명확한 수정처럼 작은 작업에는 사용하지 않는다.
+이 Skill은 공통 흐름 연결층이다. `AGENTS.md`의 의무 개발 workflow를 따른다.
 
 1. 현재 프로젝트의 `AGENTS.md`를 읽고 Docs와 Harness 경로를 계산한다.
-2. `$HARNESS_ROOT/skills/development-flow/SKILL.md`를 읽어 공통 흐름을 따른다.
-3. 구현과 검증은 현재 프로젝트의 테스트·Git 규칙을 우선한다.
+2. Task Issue와 RFC를 확인하고, 관련 문서를 읽어 조사와 계획을 끝낸다.
+3. 사용자에게 아래 문구로 workflow 진입 승인을 받고, 명시적 승인 전 구현을 시작하지 않는다.
 
-Harness 경로가 없으면 추측하지 말고 사용자에게 위치를 확인한다.
+   ```text
+   이제 이 작업에 대해 개발 workflow로 전환해서 진행할까요?
+   ```
+
+4. 승인 뒤 `.allreva/git-workflow.json` 기준 branch를 검증하고, repository-local `.worktrees/`만 사용한다.
+5. 구현·검증 뒤 PR 전 `explain-diff` 사용자 이해 승인을 받는다. 이어 제안 PR 제목·본문, 검증 근거, 잔여 위험을 제시한 뒤 별도 명시적 PR 생성 승인을 받는다. squash merge와 local cleanup은 각각 사용자 행동·cleanup signal 뒤에만 진행한다.
+6. `$HARNESS_ROOT/skills/development-flow/SKILL.md`를 읽어 공통 역할 계약을 따른다. Project-tracked adapter는 `explain-diff`와 `git-workflow`를 제공한다. Pi는 scoped custom tool과 native confirmation을 사용하며, Codex·Claude는 host/user configuration으로 경계가 약화될 수 있는 policy-only adapter다.
+
+구현과 검증은 현재 프로젝트 테스트·Git 규칙을 우선한다. Harness 경로가 없으면 추측하지 말고 사용자에게 위치를 확인한다.

--- a/.allreva/git-workflow.json
+++ b/.allreva/git-workflow.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "branch": {
+    "base": "develop",
+    "pattern": "{type}/#{issue}-{slug}"
+  },
+  "workflow": {
+    "id": "allreva-be",
+    "worktreeRoot": ".worktrees"
+  },
+  "commit": {
+    "conventional": true,
+    "types": ["feat", "fix", "docs", "test", "refactor", "chore"],
+    "requireScope": true,
+    "maxHeaderLength": 72
+  },
+  "issue": {
+    "titlePattern": "[TYPE] 설명",
+    "types": ["FEAT", "BUG", "DOCS", "REFACTOR", "TEST", "PERF", "CHORE", "HOTFIX", "CI"]
+  },
+  "pullRequest": {
+    "titlePattern": "[#{issue}] 설명"
+  }
+}

--- a/.claude/agents/explain-diff.md
+++ b/.claude/agents/explain-diff.md
@@ -1,0 +1,12 @@
+---
+name: explain-diff
+description: Create a human-readable HTML explainer and quiz for a substantial diff, branch, or PR before a person decides the next action.
+tools: Read, Grep, Glob, Bash, Write
+permissionMode: default
+---
+
+You are Allreva's explain-diff agent. Do not edit repository files, run tests, create Git artifacts, or choose product architecture.
+
+First resolve `ALLREVA_HARNESS_ROOT`. If it is unset or empty, locate `Allreva_Harness` as a sibling of the repository's primary worktree. Read `$HARNESS_ROOT/agents/explain-diff.md` and follow its role contract.
+
+You may write only the requested HTML learning artifact under the system temporary directory. If the sandbox blocks that path, do not write inside the repository; return structured artifact content to the parent so it can save the file. Return the absolute path when available and wait for the human to review it before recommending the next action.

--- a/.claude/agents/git-workflow.md
+++ b/.claude/agents/git-workflow.md
@@ -1,0 +1,12 @@
+---
+name: git-workflow
+description: Request bounded Allreva Git workflow writes with Claude Code native approval.
+tools: Read, Grep, Glob, Bash
+permissionMode: default
+---
+
+Policy-only adapter. User settings can weaken this boundary; it is not equivalent to Pi custom-tool enforcement.
+
+Read `integrations/git-write/PROTOCOL.md` from harness root. For one requested protocol operation, run read-only preflight first. Show human exact argv, cwd, branch, base/target, diff hash, and destructive status. Then request one Bash call for each fixed argv and wait for Claude Code native permission dialog. Denial stops; never substitute another command.
+
+Use only protocol argv: worktree add, push to `origin`, PR create with fixed base/head/title/body-file, or safe worktree cleanup followed by non-destructive local branch deletion. Do not stage, commit, change remotes, delete remote branches, recursively delete files, or create PR integration action. Do not create persistent permission rules or launch with permission-skipping options. Interactive use only.

--- a/.codex/agents/explain-diff.toml
+++ b/.codex/agents/explain-diff.toml
@@ -1,0 +1,11 @@
+name = "explain-diff"
+description = "Create a human-readable HTML explainer and quiz for a substantial diff, branch, or PR before a person decides the next action."
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are Allreva's explain-diff agent. Do not edit repository files, run tests, create Git artifacts, or choose product architecture.
+
+First resolve ALLREVA_HARNESS_ROOT. If it is unset or empty, locate Allreva_Harness as a sibling of the repository's primary worktree. Read $HARNESS_ROOT/agents/explain-diff.md and follow its role contract.
+
+You may write only the requested HTML learning artifact under the system temporary directory. If the sandbox blocks that path, do not write inside the repository; return structured artifact content to the parent so it can save the file. Return the absolute path when available and wait for the human to review it before recommending the next action.
+"""

--- a/.codex/agents/git-workflow.toml
+++ b/.codex/agents/git-workflow.toml
@@ -1,0 +1,11 @@
+name = "git-workflow"
+description = "Request bounded Allreva Git workflow writes with Codex native approval."
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Policy-only adapter. User configuration can weaken this boundary; it is not equivalent to Pi custom-tool enforcement.
+
+Read integrations/git-write/PROTOCOL.md from harness root. For one requested protocol operation, run read-only preflight first. Show human exact argv, cwd, branch, base/target, diff hash, and destructive status. Request escalation for one exact argv per write and wait for native approval. Denial stops; never substitute another command.
+
+Use only protocol argv: worktree add, push to origin, PR create with fixed base/head/title/body-file, or safe worktree cleanup followed by non-destructive local branch deletion. Do not stage, commit, change remotes, delete remote branches, recursively delete files, or create PR integration action. Do not create persistent permission rules or use approval-skipping launch modes. Interactive use only. Approval policy is host configuration, not set by this agent file.
+"""

--- a/.gitignore
+++ b/.gitignore
@@ -60,11 +60,33 @@ out/
 
 ### AI Tools ###
 .claude/
+!.claude/
+.claude/*
+!.claude/agents/
+.claude/agents/*
+!.claude/agents/explain-diff.md
+!.claude/agents/git-workflow.md
 .superpowers/
 .cursor/
 .copilot/
+.codex/
+!.codex/
+.codex/*
+!.codex/agents/
+.codex/agents/*
+!.codex/agents/explain-diff.toml
+!.codex/agents/git-workflow.toml
 .aider*
 .pi/
+!.pi/
+.pi/*
+!.pi/agents/
+.pi/agents/*
+!.pi/agents/explain-diff.md
+!.pi/agents/git-workflow.md
+!.pi/extensions/
+.pi/extensions/*
+!.pi/extensions/allreva-git-write.ts
 docs/*
 !docs/overview.md
 !docs/main-sequences.md

--- a/.pi/agents/explain-diff.md
+++ b/.pi/agents/explain-diff.md
@@ -1,0 +1,12 @@
+---
+name: explain-diff
+package: allreva-harness
+description: Create a human-readable HTML explainer and quiz for a substantial diff, branch, or PR before a person decides the next action.
+tools: read, grep, find, ls, bash, write
+---
+
+You are Allreva's explain-diff agent. Do not edit repository files, run tests, create Git artifacts, or choose product architecture.
+
+First resolve `ALLREVA_HARNESS_ROOT`. If it is unset or empty, locate `Allreva_Harness` as a sibling of the repository's primary worktree. Read `$HARNESS_ROOT/agents/explain-diff.md` and follow its role contract.
+
+You may write only the requested HTML learning artifact under the system temporary directory. If the sandbox blocks that path, do not write inside the repository; return structured artifact content to the parent so it can save the file. Return the absolute path when available and wait for the human to review it before recommending the next action.

--- a/.pi/agents/git-workflow.md
+++ b/.pi/agents/git-workflow.md
@@ -1,0 +1,12 @@
+---
+name: git-workflow
+package: allreva-harness
+description: Run bounded Allreva Git workflow writes through native Pi confirmation.
+tools: read, grep, find, ls, allreva_git_write
+---
+
+Use `allreva_git_write` for every Git or GitHub state change. Never use shell tool; it is intentionally absent. Read `integrations/git-write/PROTOCOL.md` from harness root before request.
+
+Only send one protocol JSON request. Explain exact operation, scope, argv, diff hash, and destructive status before tool call. Pi native dialog must be visible. Decline or blocked result stops. Do not retry by another tool. Do not stage, commit, alter remotes, delete remote branches, remove files recursively, or create PR integration action.
+
+Run only interactive Pi. Print, RPC, batch, and other noninteractive sessions cannot provide required human approval.

--- a/.pi/extensions/allreva-git-write.ts
+++ b/.pi/extensions/allreva-git-write.ts
@@ -1,0 +1,267 @@
+import { createHash, randomUUID } from "node:crypto";
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, open, readFile, writeFile } from "node:fs/promises";
+import { isAbsolute, resolve, sep } from "node:path";
+import { promisify } from "node:util";
+import { Type } from "typebox";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const execFile = promisify(execFileCallback);
+const MAX_OUTPUT = 64 * 1024;
+const MAX_BODY_BYTES = 64 * 1024;
+const TOOL_VERSION = "1";
+const operations = new Set(["worktree-create", "pr-create", "cleanup"]);
+
+export default function (pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "allreva_git_write",
+    label: "Allreva Git write",
+    description: "Run one validated Git workflow write through Pi native confirmation.",
+    parameters: Type.Object({ request: Type.String({ description: "Git write protocol v1 JSON request" }) }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const result = await runWrite(params.request, {
+        cwd: process.cwd(),
+        hasUI: ctx.hasUI,
+        confirm: (title, detail) => ctx.ui.confirm(title, detail),
+        run: runCommand,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result) }], details: result };
+    },
+  });
+}
+
+export async function runWrite(requestText, dependencies) {
+  const response = (status, operation, extra = {}) => ({ version: 1, status, operation, ...extra });
+  let request;
+  try {
+    request = validateRequest(requestText);
+  } catch (error) {
+    return response("blocked", safeOperation(requestText), { error: safeError(error) });
+  }
+  if (dependencies.hasUI !== true || typeof dependencies.confirm !== "function") {
+    return response("blocked", request.operation, { error: "Interactive native approval is unavailable." });
+  }
+
+  let before;
+  let approvalTime;
+  let attempted = false;
+  try {
+    before = await prepare(request, dependencies);
+    approvalTime = new Date().toISOString();
+    for (let index = 0; index < before.argvs.length; index += 1) {
+      const approvedArgv = before.argvs[index];
+      const approved = await dependencies.confirm("Approve Allreva Git write", confirmationDetail(before, approvedArgv));
+      if (!approved) return response("cancelled", request.operation);
+
+      if (request.operation === "cleanup" && index === 1) {
+        await revalidateCleanupBranch(before, dependencies);
+      } else {
+        const fresh = await prepare(request, dependencies);
+        if (!sameScope(before, fresh) || !sameArgv(before.argvs, fresh.argvs)) {
+          return response("blocked", request.operation, { error: "Preflight scope changed after approval." });
+        }
+      }
+      attempted = true;
+      await dependencies.run(approvedArgv[0], approvedArgv.slice(1), request.operation === "cleanup" ? before.root : dependencies.cwd);
+
+      // Push changes remote state. Check again before asking for PR creation.
+      if (request.operation === "pr-create" && index === 0) await prepare(request, dependencies);
+    }
+    const receiptPath = await writeReceipt(before, receiptCwd(before, request, dependencies), approvalTime, "succeeded");
+    return response("executed", request.operation, { receiptPath });
+  } catch (error) {
+    let receiptPath;
+    if (attempted && before && approvalTime) {
+      try { receiptPath = await writeReceipt(before, receiptCwd(before, request, dependencies), approvalTime, "failed"); } catch { /* Preserve primary write failure. */ }
+    }
+    return response("failed", request.operation, { ...(receiptPath ? { receiptPath } : {}), error: safeError(error) });
+  }
+}
+
+export function validateRequest(text) {
+  if (typeof text !== "string" || Buffer.byteLength(text, "utf8") > 16 * 1024) throw new Error("Request must be UTF-8 JSON under 16 KiB.");
+  rejectDuplicateKeys(text);
+  const value = JSON.parse(text);
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Request must be an object.");
+  const allowed = new Set(["version", "operation", "configPath", "branch", "path", "title", "bodyFile", "remote"]);
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`Unknown request key: ${key}.`);
+  if (value.version !== 1 || !operations.has(value.operation)) throw new Error("Unsupported protocol version or operation.");
+  const operationKeys = {
+    "worktree-create": new Set(["version", "operation", "configPath", "branch"]),
+    "pr-create": new Set(["version", "operation", "configPath", "title", "bodyFile", "remote"]),
+    cleanup: new Set(["version", "operation", "configPath", "path"]),
+  }[value.operation];
+  for (const key of Object.keys(value)) if (!operationKeys.has(key)) throw new Error(`Key is not allowed for ${value.operation}: ${key}.`);
+  requireRelative(value.configPath, "configPath");
+  if (value.operation === "worktree-create") requireText(value.branch, "branch", 512);
+  if (value.operation === "cleanup") requireRelative(value.path, "path");
+  if (value.operation === "pr-create") {
+    requireText(value.title, "title", 256);
+    if (value.bodyFile !== undefined) requireRelative(value.bodyFile, "bodyFile");
+    if (value.remote !== undefined && value.remote !== "origin") throw new Error("Only origin remote is supported.");
+  }
+  return value;
+}
+
+async function prepare(request, dependencies) {
+  const { cwd, run } = dependencies;
+  if (request.operation === "worktree-create") {
+    const result = await cli(run, cwd, ["worktree", "preflight", "--config", request.configPath, "--branch", request.branch]);
+    const plan = requirePlan(result, "worktree-create");
+    const argv = ["git", "worktree", "add", plan.target, "-b", request.branch, plan.base];
+    return scope(plan, [argv], request.operation, request.configPath);
+  }
+  if (request.operation === "cleanup") {
+    const result = await cli(run, cwd, ["cleanup", "preflight", "--config", request.configPath, "--path", request.path]);
+    const plan = requirePlan(result, "cleanup");
+    const expected = [["git", "worktree", "remove", plan.target], ["git", "branch", "-d", plan.branch]];
+    if (!sameArgv(expected, plan.commands) || !plan.commands.every((argv) => argv.every((part) => !String(part).startsWith("--force")))) {
+      throw new Error("Cleanup preflight returned unsafe argv.");
+    }
+    return scope(plan, expected, request.operation, request.configPath);
+  }
+
+  await cli(run, cwd, ["validate", "pr", "--config", request.configPath, "--title", request.title]);
+  const result = await cli(run, cwd, ["pr", "preflight", "--config", request.configPath]);
+  const plan = requirePlan(result, "pull-request");
+  const status = await run("git", ["status", "--porcelain=v1"], cwd);
+  if (status.stdout.trim()) throw new Error("PR worktree is not clean.");
+  const pushDestination = await getPushDestination(run, cwd, "origin");
+  try {
+    await run("gh", ["auth", "status"], cwd);
+  } catch {
+    throw new Error("GitHub authentication unavailable.");
+  }
+  const listed = await run("gh", ["pr", "list", "--head", plan.branch, "--json", "number"], cwd);
+  if (!Array.isArray(parseJson(listed.stdout)) || parseJson(listed.stdout).length !== 0) throw new Error("Existing or ambiguous pull request for branch.");
+  const create = ["gh", "pr", "create", "--base", plan.base, "--head", plan.branch, "--title", request.title];
+  const body = request.bodyFile ? await readBoundedBody(cwd, request.bodyFile) : undefined;
+  const bodyHash = body === undefined ? undefined : sha256(body);
+  if (body !== undefined) create.push("--body", body);
+  return scope(plan, [["git", "push", "-u", "origin", plan.branch], create], request.operation, request.configPath, { pushDestination, bodyHash });
+}
+
+function requirePlan(result, operation) {
+  if (!result?.ok || result?.value?.operation !== operation || !result.value.plan) throw new Error("Read-only preflight blocked write.");
+  const plan = result.value.plan;
+  for (const key of ["branch", "base", "diffHash"]) if (typeof plan[key] !== "string" || !plan[key]) throw new Error("Preflight scope is incomplete.");
+  return plan;
+}
+
+function scope(plan, argvs, operation, configPath, extra = {}) {
+  if (!Array.isArray(argvs) || argvs.length === 0 || argvs.some((argv) => !Array.isArray(argv) || argv.some((part) => typeof part !== "string" || !part))) {
+    throw new Error("Derived argv is invalid.");
+  }
+  return { operation, root: plan.root, branch: plan.branch, worktree: plan.worktree ?? plan.target, base: plan.base, diffHash: plan.diffHash, argvs, configPath, ...extra };
+}
+
+async function cli(run, cwd, args) {
+  const result = await run("allreva-git", args, cwd);
+  const parsed = parseJson(result.stdout);
+  if (!parsed || parsed.ok !== true) throw new Error("Read-only CLI preflight failed.");
+  return parsed;
+}
+
+function receiptCwd(prepared, request, dependencies) {
+  return request.operation === "cleanup" ? prepared.root : dependencies.cwd;
+}
+
+async function writeReceipt(prepared, cwd, approvedAt, outcome) {
+  const config = JSON.parse(await readFile(resolve(cwd, prepared.configPath), "utf8"));
+  const workflowId = config?.workflow?.id;
+  if (typeof workflowId !== "string" || !workflowId) throw new Error("Workflow identity unavailable for audit receipt.");
+  const receipt = {
+    receiptId: randomUUID(), platform: "pi", operation: prepared.operation, workflowId,
+    branch: prepared.branch, worktree: prepared.worktree, base: prepared.base, diffHash: prepared.diffHash,
+    argvSha256: `sha256:${createHash("sha256").update(JSON.stringify(prepared.argvs)).digest("hex")}`,
+    approvedAt, executedAt: new Date().toISOString(), outcome, toolVersion: TOOL_VERSION,
+  };
+  const directory = resolve(cwd, ".allreva", "audit");
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const path = resolve(directory, `${receipt.receiptId}.json`);
+  await writeFile(path, `${JSON.stringify(receipt)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+  return `.allreva/audit/${receipt.receiptId}.json`;
+}
+
+async function runCommand(executable, args, cwd) {
+  const result = await execFile(executable, args, { cwd, encoding: "utf8", maxBuffer: MAX_OUTPUT, windowsHide: true });
+  return { stdout: String(result.stdout ?? "").slice(0, MAX_OUTPUT), stderr: String(result.stderr ?? "").slice(0, MAX_OUTPUT) };
+}
+
+function requireText(value, name, maximum) {
+  if (typeof value !== "string" || !value || value.length > maximum || /[\u0000\r\n]/.test(value)) throw new Error(`Invalid ${name}.`);
+}
+function requireRelative(value, name) {
+  requireText(value, name, 1024);
+  if (isAbsolute(value) || /^[A-Za-z]:/.test(value) || value.split(/[\\/]+/).includes("..") || value === "." || value.startsWith(sep)) throw new Error(`Invalid relative ${name}.`);
+}
+function parseJson(text) { try { return JSON.parse(text); } catch { throw new Error("Command returned invalid JSON."); } }
+async function getPushDestination(run, cwd, remote) {
+  const output = String((await run("git", ["remote", "get-url", "--push", "--all", remote], cwd)).stdout);
+  const destinations = output.endsWith("\n") ? output.slice(0, -1).split("\n") : output.split("\n");
+  if (destinations.length !== 1) throw new Error("Expected exactly one effective push destination.");
+  return normalizeGitHubDestination(destinations[0]);
+}
+
+function normalizeGitHubDestination(value) {
+  if (typeof value !== "string" || !value || /[\u0000\r\n\s]/.test(value)) throw new Error("Push destination is invalid.");
+  const scp = /^git@github\.com:([^/\s][^\s]*)$/i.exec(value);
+  if (scp) return `ssh://git@github.com/${scp[1]}`;
+  let url;
+  try { url = new URL(value); } catch { throw new Error("Push destination is not an approved GitHub HTTPS/SSH URL."); }
+  const https = url.protocol === "https:" && !url.username && !url.password;
+  const ssh = url.protocol === "ssh:" && url.username === "git" && !url.password;
+  if ((!https && !ssh) || url.hostname.toLowerCase() !== "github.com" || url.port || url.search || url.hash || !url.pathname || url.pathname === "/") {
+    throw new Error("Push destination is not an approved GitHub HTTPS/SSH URL.");
+  }
+  return `${url.protocol}//${ssh ? "git@" : ""}github.com${url.pathname}`;
+}
+
+async function readBoundedBody(cwd, bodyFile) {
+  const handle = await open(resolve(cwd, bodyFile), "r");
+  try {
+    const buffer = Buffer.allocUnsafe(MAX_BODY_BYTES + 1);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    if (bytesRead > MAX_BODY_BYTES) throw new Error("PR body exceeds 64 KiB.");
+    const content = buffer.subarray(0, bytesRead);
+    const text = content.toString("utf8");
+    if (!Buffer.from(text, "utf8").equals(content)) throw new Error("PR body must be UTF-8.");
+    return text;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function revalidateCleanupBranch(prepared, dependencies) {
+  const { run } = dependencies;
+  try {
+    await run("git", ["show-ref", "--verify", "--quiet", `refs/heads/${prepared.branch}`], prepared.root);
+    await run("git", ["merge-base", "--is-ancestor", prepared.branch, prepared.base], prepared.root);
+    const worktrees = await run("git", ["worktree", "list", "--porcelain"], prepared.root);
+    if (worktrees.stdout.split("\n").includes(`branch refs/heads/${prepared.branch}`)) throw new Error("Cleanup branch remains checked out.");
+  } catch (error) {
+    if (error instanceof Error && error.message === "Cleanup branch remains checked out.") throw error;
+    throw new Error("Cleanup branch deletion precondition changed.");
+  }
+}
+
+function sha256(value) { return `sha256:${createHash("sha256").update(value).digest("hex")}`; }
+function sameScope(left, right) { return ["operation", "root", "branch", "worktree", "base", "diffHash", "pushDestination", "bodyHash"].every((key) => left[key] === right[key]); }
+function sameArgv(left, right) { return JSON.stringify(left) === JSON.stringify(right); }
+function confirmationDetail(prepared, argv) {
+  const displayArgv = argv[0] === "gh" && argv[1] === "pr" && argv[2] === "create" && argv.includes("--body")
+    ? argv.map((part, index) => argv[index - 1] === "--body" ? `[captured ${prepared.bodyHash}]` : part)
+    : argv;
+  return [`Operation: ${prepared.operation}`, `Branch: ${prepared.branch}`, `Worktree: ${prepared.worktree}`, `Base: ${prepared.base}`, `Diff: ${prepared.diffHash}`, ...(prepared.pushDestination ? [`Push destination: ${prepared.pushDestination}`] : []), ...(prepared.bodyHash ? [`PR body: ${prepared.bodyHash}`] : []), `Destructive: ${prepared.operation === "cleanup" ? "yes" : "no"}`, `Argv: ${JSON.stringify(displayArgv)}`].join("\n");
+}
+function safeError(error) { return error instanceof Error ? error.message.replace(/ghp_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+/g, "[redacted]").slice(0, 240) : "Write adapter failed."; }
+function safeOperation(text) { try { return JSON.parse(text)?.operation ?? "unknown"; } catch { return "unknown"; } }
+
+function rejectDuplicateKeys(text) {
+  let index = 0;
+  const whitespace = () => { while (/\s/.test(text[index] ?? "")) index += 1; };
+  const string = () => { const start = index++; let escaped = false; while (index < text.length) { const char = text[index++]; if (escaped) escaped = false; else if (char === "\\") escaped = true; else if (char === '"') return JSON.parse(text.slice(start, index)); } throw new Error("Invalid JSON string."); };
+  const value = () => { whitespace(); if (text[index] === "{") { object(); return; } if (text[index] === "[") { index += 1; whitespace(); if (text[index] === "]") { index += 1; return; } while (true) { value(); whitespace(); if (text[index] === "]") { index += 1; return; } if (text[index++] !== ",") throw new Error("Invalid JSON array."); } } if (text[index] === '"') { string(); return; } while (index < text.length && !/[\s,}\]]/.test(text[index])) index += 1; };
+  const object = () => { const keys = new Set(); index += 1; whitespace(); if (text[index] === "}") { index += 1; return; } while (true) { whitespace(); if (text[index] !== '"') throw new Error("Invalid JSON object."); const key = string(); if (keys.has(key)) throw new Error(`Duplicate request key: ${key}.`); keys.add(key); whitespace(); if (text[index++] !== ":") throw new Error("Invalid JSON object."); value(); whitespace(); if (text[index] === "}") { index += 1; return; } if (text[index++] !== ",") throw new Error("Invalid JSON object."); } };
+  value(); whitespace(); if (index !== text.length) throw new Error("Invalid JSON request.");
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,28 @@ HARNESS_ROOT="${ALLREVA_HARNESS_ROOT:-$(dirname "$MAIN_WORKTREE")/Allreva_Harnes
 
 Before work, read `$DOCS_ROOT/INDEX.md` and the applicable current document. Do not use `archive/` as a current implementation rule. If either root is unavailable, ask the user for its location rather than guessing.
 
+## Mandatory Development Workflow
+
+Every task requires an Issue and RFC. Before implementation, complete research and a plan, then ask user exactly:
+
+```text
+이제 이 작업에 대해 개발 workflow로 전환해서 진행할까요?
+```
+
+Wait for explicit approval before workflow entry. After approval:
+
+1. Validate branch against `.allreva/git-workflow.json`; create task worktrees only under ignored repository-local `.worktrees/`.
+2. Implement and verify requested change.
+3. Before PR creation, run `explain-diff` and obtain user understanding approval. Then present proposed PR title, body, validation evidence, and residual risks; obtain separate explicit PR-creation approval.
+4. User squash-merges PR. Perform local worktree or branch cleanup only after user cleanup signal.
+
+`$HARNESS_ROOT` supplies shared workflow guidance and role contracts. Project-tracked adapters expose `explain-diff` and `git-workflow`: Pi uses a scoped custom tool with native confirmation; Codex and Claude are policy-only and host/user configuration can weaken their boundary. `.pi/` local settings remain ignored. Existing GitHub title-lint workflows remain final remote title validation.
+
 ## Rules and Skills
 
-- Java code or review: read `$DOCS_ROOT/rules/backend-code-conventions.md` and the project-local `backend-java-conventions` Skill.
-- Tests: read `$DOCS_ROOT/rules/backend-test-conventions.md` and the project-local `backend-testing-conventions` Skill.
+- Java code or review: read `$DOCS_ROOT/rules/backend-code-conventions.md` and project-local `backend-java-conventions` Skill.
+- Tests: read `$DOCS_ROOT/rules/backend-test-conventions.md` and project-local `backend-testing-conventions` Skill.
 - Architecture or module-boundary changes: read `$DOCS_ROOT/architecture/` and `$DOCS_ROOT/decisions/` as applicable.
 - Issue and PR work: read `$DOCS_ROOT/rules/`.
-- Changes spanning multiple files, modules, or operational concerns: read the project-local `development-flow` Skill, which delegates to `$HARNESS_ROOT/skills/development-flow/SKILL.md`.
-- Substantial diffs, unfamiliar areas, and PR preparation: use the Pi `explain-diff` agent exposed by `$HARNESS_ROOT`.
+- Changes spanning multiple files, modules, or operational concerns: read project-local `development-flow` Skill, which delegates to `$HARNESS_ROOT/skills/development-flow/SKILL.md`.
+- Substantial diffs, unfamiliar areas, and PR preparation: use `explain-diff` role exposed by `$HARNESS_ROOT` through configured runtime.


### PR DESCRIPTION
## 배경
BE가 공통 Harness의 필수 worktree와 PR 승인 workflow를 사용하도록 연결합니다.

## 이번 PR에서 한 일
- BE Git workflow config와 worktree 식별자를 추적했습니다.
- AGENTS와 development-flow Skill에 Issue/RFC, workflow 전환 승인, worktree, PR gate, cleanup 규칙을 연결했습니다.
- Pi strong adapter와 Codex/Claude policy adapter를 프로젝트에 설치했습니다.
- local AI tool 설정은 ignore하고 필요한 adapter만 allowlist로 추적했습니다.

## 확인한 내용
- Harness source와 adapter SHA-256 일치 확인
- JSON/TOML parse
- `git check-ignore`로 allowlist 검증
- `git diff --check`
- 독립 reviewer 검토 통과

## 남은 확인 사항
- Pi, Codex, Claude native UI의 disposable repository 수동 TTY 검증은 아직 수행하지 않았습니다.
- Codex와 Claude adapter는 정책형 경계입니다.

## 관련 문서
- 기준 문서: Allreva_Docs#19
- Harness: Allreva_Harness#1
- 관련 Issue: closes #123
