### PR TITLE
[#125] BE untracked 정책 복구

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ out/
 !.codex/agents/git-workflow.toml
 .aider*
 .pi/
+.pi-subagents/
 !.pi/
 .pi/*
 !.pi/agents/
@@ -104,3 +105,4 @@ query-optimization-test/
 
 ### Seed Data ###
 src/main/resources/seed/
+allreva-support/db/src/main/resources/db/seed/


### PR DESCRIPTION
## 배경
workflow integration merge 뒤 `.pi-subagents`와 nested KOPIS seed ignore 규칙이 빠져 로컬 생성물이 untracked로 다시 보였습니다.

## 이번 PR에서 한 일
- `.pi-subagents/` 실행 산출물을 ignore합니다.
- `allreva-support/db/src/main/resources/db/seed/` 전체를 ignore합니다.

## 확인한 내용
- `git check-ignore -v`로 두 대상 경로 확인
- `git diff --check`

## 남은 확인 사항
- KOPIS 수집 도구와 API 키 환경변수화는 별도 재설계 대상입니다.
- base 최신화 전에 만든 stash는 merge 뒤 동일한 두 줄인지 재확인 후 삭제합니다.

## 관련 문서
- 기준 문서: 없음
- 관련 Issue: closes #125
