### PR TITLE
[#129] PR 올릴 때 일부 파일이 빠지는 문제를 해결한다

### DIFF
--- a/.agents/skills/development-flow/SKILL.md
+++ b/.agents/skills/development-flow/SKILL.md
@@ -16,7 +16,8 @@ description: Allreva BE에서 여러 파일·모듈·운영 영향이 있는 변
    ```
 
 4. 승인 뒤 `.allreva/git-workflow.json` 기준 branch를 검증하고, repository-local `.worktrees/`만 사용한다.
-5. 구현·검증 뒤 PR 전 `explain-diff` 사용자 이해 승인을 받는다. 이어 제안 PR 제목·본문, 검증 근거, 잔여 위험을 제시한 뒤 별도 명시적 PR 생성 승인을 받는다. squash merge와 local cleanup은 각각 사용자 행동·cleanup signal 뒤에만 진행한다.
-6. `$HARNESS_ROOT/skills/development-flow/SKILL.md`를 읽어 공통 역할 계약을 따른다. Project-tracked adapter는 `explain-diff`와 `git-workflow`를 제공한다. Pi는 scoped custom tool과 native confirmation을 사용하며, Codex·Claude는 host/user configuration으로 경계가 약화될 수 있는 policy-only adapter다.
+5. PR review 또는 생성 전 completeness preflight를 수행한다. 의도한 diff를 `git status --short`, `git diff --cached --name-status`, `git diff --name-status`, `git status --ignored --short`와 비교하고, Task 관련 ignored/generated path를 확인한다. 남은 모든 변경·path에 include, exclude, expected-generated/ignored 설명을 명시한다. 설명되지 않은 변경은 제거하거나 설명할 때까지 PR review와 생성을 막는다.
+6. 구현·검증 뒤 PR 전 `explain-diff` 사용자 이해 승인을 받는다. 이어 제안 PR 제목·본문, 검증 근거, 잔여 위험을 제시한 뒤 별도 명시적 PR 생성 승인을 받는다. squash merge와 local cleanup은 각각 사용자 행동·cleanup signal 뒤에만 진행한다.
+7. `$HARNESS_ROOT/skills/development-flow/SKILL.md`를 읽어 공통 역할 계약을 따른다. Project-tracked adapter는 `explain-diff`와 `git-workflow`를 제공한다. Pi는 scoped custom tool과 native confirmation을 사용하며, Codex·Claude는 host/user configuration으로 경계가 약화될 수 있는 policy-only adapter다.
 
 구현과 검증은 현재 프로젝트 테스트·Git 규칙을 우선한다. Harness 경로가 없으면 추측하지 말고 사용자에게 위치를 확인한다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,9 @@ Wait for explicit approval before workflow entry. After approval:
 
 1. Validate branch against `.allreva/git-workflow.json`; create task worktrees only under ignored repository-local `.worktrees/`.
 2. Implement and verify requested change.
-3. Before PR creation, run `explain-diff` and obtain user understanding approval. Then present proposed PR title, body, validation evidence, and residual risks; obtain separate explicit PR-creation approval.
-4. User squash-merges PR. Perform local worktree or branch cleanup only after user cleanup signal.
+3. Before PR review or creation, run a PR completeness preflight. Compare intended diff against `git status --short`, `git diff --cached --name-status`, `git diff --name-status`, and `git status --ignored --short`; inspect ignored/generated paths relevant to task. Every remaining change or path needs explicit include, exclude, or expected-generated/ignored explanation. Block PR review and creation until each unexplained change is removed or explained.
+4. Before PR creation, run `explain-diff` and obtain user understanding approval. Then present proposed PR title, body, validation evidence, and residual risks; obtain separate explicit PR-creation approval.
+5. User squash-merges PR. Perform local worktree or branch cleanup only after user cleanup signal.
 
 `$HARNESS_ROOT` supplies shared workflow guidance and role contracts. Project-tracked adapters expose `explain-diff` and `git-workflow`: Pi uses a scoped custom tool with native confirmation; Codex and Claude are policy-only and host/user configuration can weaken their boundary. `.pi/` local settings remain ignored. Existing GitHub title-lint workflows remain final remote title validation.
 


### PR DESCRIPTION
## 왜 바꾸나요?
BE 작업에서도 PR을 만들기 전에 빠진 변경이 없는지 확인합니다.

## 무엇을 바꾸나요?
AGENTS와 development-flow Skill에 현재 수정, stage한 파일, 아직 stage하지 않은 파일, 새 파일, ignore된 생성 파일을 함께 확인하고 설명되지 않은 변경이 있으면 PR을 막는 규칙을 연결합니다.

## 어떻게 확인했나요?
- git diff --check
- 독립 review

## 아직 남은 점
없음

## 관련 문서
- 기준 문서: Allreva_Docs#24
- 관련 Issue: closes #129